### PR TITLE
chore: redefine infrahub-sdk version dependency, update README, 0.2.2 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# [Nornir](https://github.com/nornir-automation/nornir) plugin for [Infrahub][]
+# [Nornir](https://github.com/nornir-automation/nornir) plugin for [Infrahub][https://github.com/opsmill/infrahub]
 
-Work in progress.
+## Installation
+
+	pip install nornir_infrahub
+
+## Infrahub as the Nornir inventory
+
+Infrahub can be used as an inventory source for Nonir.
+An example of this can be found in [./examples/nornir_inventory.py](./examples/nornir_inventory.py)
+
+## Infrahub Artifact Tasks
+
+A set of tasks are provided to operate on Infrahub Artifacts.
+- `generate_artifacts`: generates the Artifacts for a Artifact Definition
+- `regenerate_artifact`: re-generates an Artifact for a Nornir Host
+- `get_artifact`: retrieve an Artifact for a Nornir Host
+
+An example of this can be found in [./examples/nornir_tasks.py](./examples/nornir_tasks.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir-infrahub"
-version = "0.2.1"
+version = "0.2.2"
 description = "Nornir plugin for Infrahub"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8, <3.12"
-infrahub-sdk = "^0.3.0"
+infrahub-sdk = "^0.3"
 ruamel-yaml = "^0.18.5"
 nornir = "^3.4.1"
 nornir-utils = "^0.2.0"


### PR DESCRIPTION
- Redefines `infrahub-sdk` version spec to ^0.3
- Adds some extra information to the README
- Version bump to 0.2.2