### PR TITLE
handle error if group has no peers

### DIFF
--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Type, Union
 
 import ruamel.yaml
-from infrahub_sdk import Config, InfrahubClientSync, InfrahubNodeSync, NodeNotFoundError, NodeSchema
+from infrahub_sdk import Config, InfrahubClientSync, InfrahubNodeSync, NodeSchema
 from nornir.core.inventory import (
     ConnectionOptions,
     Defaults,
@@ -222,10 +222,8 @@ class InfrahubInventory:
 
             extracted_groups = []
             for related_node in host_node.member_of_groups.peers:
-                try:
+                if related_node.typename == "CoreStandardGroup":
                     extracted_groups.append(related_node.peer.name.value)
-                except NodeNotFoundError:
-                    continue
 
             for group_mapping in self.group_mappings:
                 attrs = group_mapping.split(".")

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -220,10 +220,11 @@ class InfrahubInventory:
             host["data"] = {"InfrahubNode": host_node}
             hosts[name] = _get_inventory_element(Host, host, name, defaults)
 
-            extracted_groups = []
-            for related_node in host_node.member_of_groups.peers:
-                if related_node.typename == "CoreStandardGroup":
-                    extracted_groups.append(related_node.peer.name.value)
+            extracted_groups = [
+                related_node.peer.name.value
+                for related_node in host_node.member_of_groups.peers
+                if related_node.typename == "CoreStandardGroup"
+            ]
 
             for group_mapping in self.group_mappings:
                 attrs = group_mapping.split(".")


### PR DESCRIPTION
Inventory couldn't be built if no node was present in a group. For more information see #17, fixes #17 