### PR TITLE
Add option to get artifact by id

### DIFF
--- a/docs/docs/references/plugins/artifact_tasks.mdx
+++ b/docs/docs/references/plugins/artifact_tasks.mdx
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
 Retrieves the specified artifact from the Infrahub storage.
 
-This function fetches an artifact node associated with the given artifact name and
+This function fetches an artifact node associated with the given artifact name or id and
 sends a request to retrieve its stored content. The response is returned as JSON or text,
 depending on the artifact's content type.
 
@@ -101,7 +101,8 @@ depending on the artifact's content type.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `task` | `Task` | Yes |  | The task instance containing host-related data. |
-| `artifact` | `str` | Yes |  | The name of the artifact to retrieve. |
+| `artifact` | `str` | No |  | The name of the artifact to retrieve. |
+| `artifact_id` | `str` | No |  | The id of the artifact to retrieve. |
 
 ### Examples
 

--- a/docs/docs/references/plugins/infrahub_inventory.mdx
+++ b/docs/docs/references/plugins/infrahub_inventory.mdx
@@ -29,13 +29,8 @@ from Infrahub Nodes.
 
 ```python
 from nornir import InitNornir
-from nornir.core.plugins.inventory import InventoryPluginRegister
-from nornir_infrahub.plugins.inventory.infrahub import InfrahubInventory
 
 def main():
-    # Register the custom InfrahubInventory plugin
-    InventoryPluginRegister.register("InfrahubInventory", InfrahubInventory)
-
     # Initialize Nornir with InfrahubInventory as the inventory plugin
     nr = InitNornir(
         inventory={

--- a/nornir_infrahub/plugins/tasks/artifact.py
+++ b/nornir_infrahub/plugins/tasks/artifact.py
@@ -2,6 +2,8 @@
 Artifact management plugin
 """
 
+from typing import Optional
+
 import httpx
 from nornir.core.task import Result, Task
 
@@ -126,17 +128,18 @@ def generate_artifacts(task: Task, artifact: str, timeout: int = 10) -> Result:
     return Result(host=task.host, failed=False)
 
 
-def get_artifact(task: Task, artifact: str) -> Result:
+def get_artifact(task: Task, artifact: Optional[str] = None, artifact_id: Optional[str] = None) -> Result:
     """
     Retrieves the specified artifact from the Infrahub storage.
 
-    This function fetches an artifact node associated with the given artifact name and
+    This function fetches an artifact node associated with the given artifact name or id and
     sends a request to retrieve its stored content. The response is returned as JSON or text,
     depending on the artifact's content type.
 
     Args:
         task (Task): The task instance containing host-related data.
-        artifact (str): The name of the artifact to retrieve.
+        artifact (str, optional): The name of the artifact to retrieve.
+        artifact_id (str, optional): The id of the artifact to retrieve.
 
     Returns:
         Result: An object containing the retrieved artifact data, its content type, and
@@ -172,16 +175,25 @@ def get_artifact(task: Task, artifact: str) -> Result:
             raise SystemExit(main())
         ```
     """
+    if (artifact and artifact_id) or not (artifact or artifact_id):
+        raise RuntimeError(
+            "One of `artifact' or `artifact_id' arguments needs to be provided for the `get_artifact' task."
+        )
+
     node = task.host.data["InfrahubNode"]
+    client = node._client
 
-    artifact_node = node._client.get(kind="CoreArtifact", name__value=artifact, object__ids=[node.id])
+    if artifact:
+        artifact_node = client.get(kind="CoreArtifact", name__value=artifact, object__ids=[node.id])
+    elif artifact_id:
+        artifact_node = client.get(kind="CoreArtifact", ids=[artifact_id])
 
-    headers = node._client.headers
-    headers["X-INFRAHUB-KEY"] = f"{node._client.config.api_token}"
+    headers = client.headers
+    headers["X-INFRAHUB-KEY"] = f"{client.config.api_token}"
 
-    with httpx.Client() as client:
-        resp = client.get(
-            url=f"{node._client.address}/api/storage/object/{artifact_node.storage_id.value}",
+    with httpx.Client() as http_client:
+        resp = http_client.get(
+            url=f"{client.address}/api/storage/object/{artifact_node.storage_id.value}",
             headers=headers,
         )
     resp.raise_for_status()


### PR DESCRIPTION
Adds an optional argument `artifact_id` to the `get_artifact` task plugin, to retrieve an artifact by its id.