### PR TITLE
fix inventory filtering

### DIFF
--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -246,8 +246,9 @@ class InfrahubInventory:
         for n, g in groups_dict.items():
             groups[n] = _get_inventory_element(Group, g, n, defaults)
 
+
         for g in groups.values():
-            g.groups = ParentGroups([groups[g] for g in g.groups])
+            g.groups = ParentGroups([groups[g.name] for g in g.groups])
 
         host: Dict[str, Any] = {}
 

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -299,5 +299,5 @@ class InfrahubInventory:
         if "filters" in kwargs:
             filters = kwargs.pop("filters")
 
-        resources = self.client.all(kind=kind, branch=self.branch, populate_store=True, **kwargs, **filters)
+        resources = self.client.filters(kind=kind, branch=self.branch, populate_store=True, **kwargs, **filters)
         return resources

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -246,7 +246,6 @@ class InfrahubInventory:
         for n, g in groups_dict.items():
             groups[n] = _get_inventory_element(Group, g, n, defaults)
 
-
         for g in groups.values():
             g.groups = ParentGroups([groups[g.name] for g in g.groups])
 

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -372,7 +372,7 @@ def test_infrahub_inventory_branch_used_in_get_resources():
         mock_schema = Mock()
         mock_schema.relationships = []  # Empty list to avoid iteration error
         mock_client.schema.get.return_value = mock_schema
-        mock_client.all.return_value = []
+        mock_client.filters.return_value = []
         mock_client_class.return_value = mock_client
 
         inventory = InfrahubInventory(host_node={"kind": "InfraDevice"}, branch=custom_branch)
@@ -381,8 +381,8 @@ def test_infrahub_inventory_branch_used_in_get_resources():
         inventory.get_resources(kind="InfraDevice")
 
         # Verify that client.all was called with the correct branch
-        mock_client.all.assert_called_once()
-        call_args = mock_client.all.call_args
+        mock_client.filters.assert_called_once()
+        call_args = mock_client.filters.call_args
         assert call_args[1]["branch"] == custom_branch
         assert call_args[1]["kind"] == "InfraDevice"
         assert call_args[1]["populate_store"] is True


### PR DESCRIPTION
We were using the `client.all` method of the Infrahub SDK instead of the `client.filters` method, in the `get_resources` function of the inventory plugin.

This caused an issue when users defined a filter in the inventory configuration.
For example:
```yaml
    host_node:
      kind: "InfraDevice"
      filters:
        status__value: "active"

```