### PR TITLE
Initial support for file upload

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "MD012": false,
+  "MD013": false,
+  "MD014": false,
+  "MD024": false,
+  "MD032": false,
+  "MD034": false,
+  "MD060": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,0 @@
-{
-  "MD012": false,
-  "MD013": false,
-  "MD014": false,
-  "MD024": false,
-  "MD032": false,
-  "MD034": false,
-  "MD060": false
-}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -14,4 +14,5 @@ MD034: false    # no-bare-urls
 MD045: false    # no alt text around images
 MD047: false    # single trailing newline
 MD014: false    # dollar signs used before commands
+MD012: false    # allows the blank lines emitted between generated plugin doc sections
 MD060: false    # table column alignment — impractical with wide description columns

--- a/.vale/styles/Infrahub/sentence-case.yml
+++ b/.vale/styles/Infrahub/sentence-case.yml
@@ -51,6 +51,9 @@ exceptions:
   - Context Menu Integration
   - Context Menus
   - CoreArtifactTarget
+  - CoreFileObject
+  - CoreFileObject management tasks
+  - Upload a contract PDF to a CoreFileObject node
   - CoreGroup
   - CoreRepository
   - Create an application in Entra ID

--- a/.vale/styles/Infrahub/sentence-case.yml
+++ b/.vale/styles/Infrahub/sentence-case.yml
@@ -53,7 +53,7 @@ exceptions:
   - CoreArtifactTarget
   - CoreFileObject
   - CoreFileObject management tasks
-  - Upload a contract PDF to a CoreFileObject node
+  - Upload a contract PDF to a CoreFileObject object
   - CoreGroup
   - CoreRepository
   - Create an application in Entra ID

--- a/.vale/styles/Infrahub/spelling.yml
+++ b/.vale/styles/Infrahub/spelling.yml
@@ -5,4 +5,5 @@ level: error
 filters:
   - '[pP]y.*\b'
   - '\bimport_.*\b'    # New filter to ignore variables starting with 'import_'
+  - '\b\w+_\w+\b'      # Ignore snake_case identifiers (function/variable names)
 ignore: spelling-exceptions.txt

--- a/docs/_templates/plugin.mdx.j2
+++ b/docs/_templates/plugin.mdx.j2
@@ -14,7 +14,7 @@ title: {{ module }}
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
 {%- for param in documentation.params %}
-| `{{ param.arg_name }}` | `{{ param.type_name }}` | {{ "No" if param.is_optional else "Yes" }} | {{ param.default if param.default else "" }} | {{ param.description }} |
+| `{{ param.arg_name }}` | `{{ param.type_name | replace('|', '\\|') }}` | {{ "No" if param.is_optional else "Yes" }} | {{ param.default if param.default else "" }} | {{ param.description | replace('\n', ' ') }} |
 {%- endfor %}
 {%- endif %}
 

--- a/docs/_templates/plugin.mdx.j2
+++ b/docs/_templates/plugin.mdx.j2
@@ -2,16 +2,17 @@
 title: {{ module }}
 ---
 {% for function_name, documentation in functions.items() %}
+
 ## `{{ function_name }}`
 
 {{ documentation.description }}
 
-{%- if documentation.params is defined %}
+{%- if documentation.params is defined and documentation.params %}
 
 ### Parameters
 
 | Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
+| --------- | ---- | -------- | ------- | ----------- |
 {%- for param in documentation.params %}
 | `{{ param.arg_name }}` | `{{ param.type_name }}` | {{ "No" if param.is_optional else "Yes" }} | {{ param.default if param.default else "" }} | {{ param.description }} |
 {%- endfor %}
@@ -26,6 +27,7 @@ title: {{ module }}
 {{ example.description.split("\n", 1)[1] }}
 {% endfor %}
 {%- else %}
+
 No example provided.
 {%- endif %}
 {%- endfor %}

--- a/docs/_templates/readme.mdx.j2
+++ b/docs/_templates/readme.mdx.j2
@@ -20,7 +20,7 @@ pip install nornir_infrahub
 {% for module in plugin %}
 #### {{ module.module }}
 {% for function_name, function in module.functions.items() %}
-- [{{ function_name }}](./references/plugins/{{ module.file_name }}#{{ function_name.lower() }})
+- [{{ function_name }}](./{{ module.file_name }}#{{ function_name.lower() }})
 {% endfor %}
 {%- endfor %}
 {%- endfor %}

--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -66,6 +66,11 @@ pip install nornir-infrahub
 - [generate_artifacts](./references/plugins/artifact_tasks.mdx#generate_artifacts)
 - [get_artifact](./references/plugins/artifact_tasks.mdx#get_artifact)
 
+#### CoreFileObject management tasks
+
+- [upload_file_object](./references/plugins/file_object_tasks.mdx#upload_file_object)
+- [download_file_object](./references/plugins/file_object_tasks.mdx#download_file_object)
+
 ## Additional resources
 
 - [Blog: Simplifying Network Automation Workflows with Infrahub, Nornir, and Jinja2](https://www.opsmill.com/simplifying-network-automation-workflows-with-infrahub-nornir-and-jinja2/)

--- a/docs/docs/references/plugins/_plugin_index.mdx
+++ b/docs/docs/references/plugins/_plugin_index.mdx
@@ -20,20 +20,20 @@ pip install nornir_infrahub
 
 #### Inventory plugin
 
-- [InfrahubInventory](./references/plugins/infrahub_inventory.mdx#infrahubinventory)
+- [InfrahubInventory](./infrahub_inventory.mdx#infrahubinventory)
 
 ### Tasks
 
 #### Artifact management plugin
 
-- [regenerate_host_artifact](./references/plugins/artifact_tasks.mdx#regenerate_host_artifact)
+- [regenerate_host_artifact](./artifact_tasks.mdx#regenerate_host_artifact)
 
-- [generate_artifacts](./references/plugins/artifact_tasks.mdx#generate_artifacts)
+- [generate_artifacts](./artifact_tasks.mdx#generate_artifacts)
 
-- [get_artifact](./references/plugins/artifact_tasks.mdx#get_artifact)
+- [get_artifact](./artifact_tasks.mdx#get_artifact)
 
 #### CoreFileObject management tasks
 
-- [upload_file_object](./references/plugins/file_object_tasks.mdx#upload_file_object)
+- [upload_file_object](./file_object_tasks.mdx#upload_file_object)
 
-- [download_file_object](./references/plugins/file_object_tasks.mdx#download_file_object)
+- [download_file_object](./file_object_tasks.mdx#download_file_object)

--- a/docs/docs/references/plugins/_plugin_index.mdx
+++ b/docs/docs/references/plugins/_plugin_index.mdx
@@ -20,14 +20,20 @@ pip install nornir_infrahub
 
 #### Inventory plugin
 
-- [InfrahubInventory](./infrahub_inventory.mdx#infrahubinventory)
+- [InfrahubInventory](./references/plugins/infrahub_inventory.mdx#infrahubinventory)
 
 ### Tasks
 
 #### Artifact management plugin
 
-- [regenerate_host_artifact](./artifact_tasks.mdx#regenerate_host_artifact)
+- [regenerate_host_artifact](./references/plugins/artifact_tasks.mdx#regenerate_host_artifact)
 
-- [generate_artifacts](./artifact_tasks.mdx#generate_artifacts)
+- [generate_artifacts](./references/plugins/artifact_tasks.mdx#generate_artifacts)
 
-- [get_artifact](./artifact_tasks.mdx#get_artifact)
+- [get_artifact](./references/plugins/artifact_tasks.mdx#get_artifact)
+
+#### CoreFileObject management tasks
+
+- [upload_file_object](./references/plugins/file_object_tasks.mdx#upload_file_object)
+
+- [download_file_object](./references/plugins/file_object_tasks.mdx#download_file_object)

--- a/docs/docs/references/plugins/artifact_tasks.mdx
+++ b/docs/docs/references/plugins/artifact_tasks.mdx
@@ -2,6 +2,7 @@
 title: Artifact management plugin
 ---
 
+
 ## `regenerate_host_artifact`
 
 Regenerates a host artifact for a given task.
@@ -13,8 +14,8 @@ then sends a request to regenerate the artifact using the Infrahub API.
 
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
-| `task` | `Task` | Yes | - | The task instance containing host-related data. |
-| `artifact` | `str` | Yes | - | The name of the artifact to regenerate. |
+| `task` | `Task` | Yes |  | The task instance containing host-related data. |
+| `artifact` | `str` | Yes |  | The name of the artifact to regenerate. |
 
 ### Examples
 
@@ -45,6 +46,7 @@ if __name__ == "__main__":
     raise SystemExit(main())
 ```
 
+
 ## `generate_artifacts`
 
 Generates an artifact for a given task.
@@ -56,8 +58,8 @@ an API request to generate the specified artifact.
 
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
-| `task` | `Task` | Yes | - | The task instance containing host-related data. |
-| `artifact` | `str` | Yes | - | The name of the artifact to generate. |
+| `task` | `Task` | Yes |  | The task instance containing host-related data. |
+| `artifact` | `str` | Yes |  | The name of the artifact to generate. |
 | `timeout` | `int` | No | 10 | The request timeout in seconds. Defaults to 10. |
 
 ### Examples
@@ -88,6 +90,7 @@ if __name__ == "__main__":
     raise SystemExit(main())
 ```
 
+
 ## `get_artifact`
 
 Retrieves the specified artifact from the Infrahub storage.
@@ -100,9 +103,9 @@ depending on the artifact's content type.
 
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
-| `task` | `Task` | Yes | - | The task instance containing host-related data. |
-| `artifact` | `str` | No | - | The name of the artifact to retrieve. |
-| `artifact_id` | `str` | No | - | The id of the artifact to retrieve. |
+| `task` | `Task` | Yes |  | The task instance containing host-related data. |
+| `artifact` | `str` | No |  | The name of the artifact to retrieve. |
+| `artifact_id` | `str` | No |  | The id of the artifact to retrieve. |
 
 ### Examples
 

--- a/docs/docs/references/plugins/file_object_tasks.mdx
+++ b/docs/docs/references/plugins/file_object_tasks.mdx
@@ -1,0 +1,73 @@
+---
+title: CoreFileObject management tasks
+---
+
+
+## `upload_file_object`
+
+Uploads a local file to an Infrahub CoreFileObject node.
+
+Creates the node if it does not exist, or updates it if the file content
+has changed (SHA-1 checksum comparison).  When the local file is identical
+to the one stored on the server the upload is skipped (idempotent).
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+| --------- | ---- | -------- | ------- | ----------- |
+| `task` | `Task` | Yes |  | The Nornir task instance containing host-related data. |
+| `kind` | `str` | Yes |  | The schema kind that inherits from CoreFileObject. |
+| `file_path` | `str` | Yes |  | Local filesystem path to the file to upload. |
+| `data` | `dict` | No |  | Additional node attributes to set on create or update. |
+| `node_id` | `str` | No |  | UUID of an existing node to update. |
+| `hfid` | `list[str]` | No |  | HFID components identifying an existing node. |
+| `branch` | `str` | No | the client's default branch | Target Infrahub branch. Defaults to the client's default branch. |
+
+### Examples
+
+#### Upload a contract PDF to a CoreFileObject node
+
+```python
+from nornir_infrahub.plugins.tasks import upload_file_object
+
+result = nr.run(
+    task=upload_file_object,
+    kind="NetworkCircuitContract",
+    file_path="/path/to/contract.pdf",
+    data={"contract_start": "2026-01-01"},
+)
+```
+
+
+## `download_file_object`
+
+Downloads file content from an Infrahub CoreFileObject node.
+
+Returns the file content as base64-encoded binary data, with a UTF-8
+text representation for text MIME types.  Optionally saves the file
+to a local destination path.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+| --------- | ---- | -------- | ------- | ----------- |
+| `task` | `Task` | Yes |  | The Nornir task instance containing host-related data. |
+| `kind` | `str` | Yes |  | The schema kind that inherits from CoreFileObject. |
+| `node_id` | `str` | No |  | UUID of the node to download from. |
+| `hfid` | `list[str]` | No |  | HFID components identifying the node. |
+| `dest` | `str` | No |  | Local path to save the downloaded file. Directories get the original file name appended. |
+| `branch` | `str` | No | the client's default branch | Target Infrahub branch. Defaults to the client's default branch. |
+
+### Examples
+
+#### Download a file from a CoreFileObject node
+
+```python
+from nornir_infrahub.plugins.tasks import download_file_object
+
+result = nr.run(
+    task=download_file_object,
+    kind="NetworkCircuitContract",
+    hfid=["contract-2026"],
+)
+```

--- a/docs/docs/references/plugins/file_object_tasks.mdx
+++ b/docs/docs/references/plugins/file_object_tasks.mdx
@@ -20,7 +20,7 @@ Provide either ``file_path`` (to upload a file from disk) or ``content`` with
 | --------- | ---- | -------- | ------- | ----------- |
 | `task` | `Task` | Yes |  | The Nornir task instance containing host-related data. |
 | `kind` | `str` | Yes |  | The schema kind that inherits from CoreFileObject. |
-| `file_path` | `str | Path` | No |  | Filesystem path to the file to upload. |
+| `file_path` | `str \| Path` | No |  | Filesystem path to the file to upload. |
 | `content` | `bytes` | No |  | Raw file content to upload. Requires ``file_name``. |
 | `file_name` | `str` | No |  | File name to associate with ``content``. Ignored when ``file_path`` is used. |
 | `data` | `dict` | No |  | Additional object attributes to set on create or update. |
@@ -65,8 +65,7 @@ server-side checksum, the download is skipped and ``changed`` is ``False``
 | `kind` | `str` | Yes |  | The schema kind that inherits from CoreFileObject. |
 | `object_id` | `str` | No |  | UUID of the object to download from. |
 | `hfid` | `list[str]` | No |  | HFID components identifying the object. |
-| `save_to` | `str | Path` | No |  | Local path where the downloaded file should be written.
-A directory receives the original file name; an explicit path is used as-is. |
+| `save_to` | `str \| Path` | No |  | Local path where the downloaded file should be written. A directory receives the original file name; an explicit path is used as-is. |
 | `branch` | `str` | No | the client's default branch | Target Infrahub branch. Defaults to the client's default branch. |
 
 ### Examples

--- a/docs/docs/references/plugins/file_object_tasks.mdx
+++ b/docs/docs/references/plugins/file_object_tasks.mdx
@@ -27,7 +27,7 @@ Provide either ``file_path`` (to upload a file from disk) or ``content`` with
 | `object_id` | `str` | No |  | UUID of an existing object to update. |
 | `hfid` | `list[str]` | No |  | HFID components identifying an existing object. |
 | `branch` | `str` | No | the client's default branch | Target Infrahub branch. Defaults to the client's default branch. |
-| `**kwargs` | `None` | Yes |  | Extra keyword arguments forwarded to ``client.create`` (e.g. ``allow_upsert``, ``timeout``). |
+| `**kwargs` | `Any` | No |  | Extra keyword arguments forwarded to ``client.create`` (e.g. ``allow_upsert``, ``timeout``). |
 
 ### Examples
 

--- a/docs/docs/references/plugins/file_object_tasks.mdx
+++ b/docs/docs/references/plugins/file_object_tasks.mdx
@@ -5,11 +5,14 @@ title: CoreFileObject management tasks
 
 ## `upload_file_object`
 
-Uploads a local file to an Infrahub CoreFileObject node.
+Uploads a file to an Infrahub CoreFileObject object.
 
-Creates the node if it does not exist, or updates it if the file content
-has changed (SHA-1 checksum comparison).  When the local file is identical
+Creates the object if it does not exist, or updates it if the file content
+has changed (SHA-1 checksum comparison).  When the local content is identical
 to the one stored on the server the upload is skipped (idempotent).
+
+Provide either ``file_path`` (to upload a file from disk) or ``content`` with
+``file_name`` (to upload raw bytes).
 
 ### Parameters
 
@@ -17,15 +20,18 @@ to the one stored on the server the upload is skipped (idempotent).
 | --------- | ---- | -------- | ------- | ----------- |
 | `task` | `Task` | Yes |  | The Nornir task instance containing host-related data. |
 | `kind` | `str` | Yes |  | The schema kind that inherits from CoreFileObject. |
-| `file_path` | `str` | Yes |  | Local filesystem path to the file to upload. |
-| `data` | `dict` | No |  | Additional node attributes to set on create or update. |
-| `node_id` | `str` | No |  | UUID of an existing node to update. |
-| `hfid` | `list[str]` | No |  | HFID components identifying an existing node. |
+| `file_path` | `str | Path` | No |  | Filesystem path to the file to upload. |
+| `content` | `bytes` | No |  | Raw file content to upload. Requires ``file_name``. |
+| `file_name` | `str` | No |  | File name to associate with ``content``. Ignored when ``file_path`` is used. |
+| `data` | `dict` | No |  | Additional object attributes to set on create or update. |
+| `object_id` | `str` | No |  | UUID of an existing object to update. |
+| `hfid` | `list[str]` | No |  | HFID components identifying an existing object. |
 | `branch` | `str` | No | the client's default branch | Target Infrahub branch. Defaults to the client's default branch. |
+| `**kwargs` | `None` | Yes |  | Extra keyword arguments forwarded to ``client.create`` (e.g. ``allow_upsert``, ``timeout``). |
 
 ### Examples
 
-#### Upload a contract PDF to a CoreFileObject node
+#### Upload a contract PDF to a CoreFileObject object
 
 ```python
 from nornir_infrahub.plugins.tasks import upload_file_object
@@ -41,11 +47,15 @@ result = nr.run(
 
 ## `download_file_object`
 
-Downloads file content from an Infrahub CoreFileObject node.
+Downloads file content from an Infrahub CoreFileObject object.
 
 Returns the file content as base64-encoded binary data, with a UTF-8
 text representation for text MIME types.  Optionally saves the file
-to a local destination path.
+to a local path.
+
+When ``save_to`` points to an existing file whose SHA-1 matches the
+server-side checksum, the download is skipped and ``changed`` is ``False``
+(idempotent, similar to ``nornir_utils.plugins.tasks.files.write_file``).
 
 ### Parameters
 
@@ -53,14 +63,15 @@ to a local destination path.
 | --------- | ---- | -------- | ------- | ----------- |
 | `task` | `Task` | Yes |  | The Nornir task instance containing host-related data. |
 | `kind` | `str` | Yes |  | The schema kind that inherits from CoreFileObject. |
-| `node_id` | `str` | No |  | UUID of the node to download from. |
-| `hfid` | `list[str]` | No |  | HFID components identifying the node. |
-| `dest` | `str` | No |  | Local path to save the downloaded file. Directories get the original file name appended. |
+| `object_id` | `str` | No |  | UUID of the object to download from. |
+| `hfid` | `list[str]` | No |  | HFID components identifying the object. |
+| `save_to` | `str | Path` | No |  | Local path where the downloaded file should be written.
+A directory receives the original file name; an explicit path is used as-is. |
 | `branch` | `str` | No | the client's default branch | Target Infrahub branch. Defaults to the client's default branch. |
 
 ### Examples
 
-#### Download a file from a CoreFileObject node
+#### Download a file from a CoreFileObject object
 
 ```python
 from nornir_infrahub.plugins.tasks import download_file_object

--- a/docs/docs/references/plugins/infrahub_inventory.mdx
+++ b/docs/docs/references/plugins/infrahub_inventory.mdx
@@ -2,6 +2,7 @@
 title: Inventory plugin
 ---
 
+
 ## `InfrahubInventory`
 
 Nornir inventory plugin for integrating with `Opsmill - Infrahub`
@@ -15,13 +16,13 @@ from Infrahub Nodes.
 
 | Parameter | Type | Required | Default | Description |
 | --------- | ---- | -------- | ------- | ----------- |
-| `address` | `str` | No | `"http://localhost:8000"` | The Infrahub URL to connect to. |
-| `branch` | `str` | No | `"main"` | The Infrahub branch to use. |
-| `host_node` | `dict` | Yes | - | A dictionary defining the Infrahub Node kind that will be mapped to Nornir Hosts. Example: `{"kind": "InfraDevice"}` |
-| `schema_mappings` | `list` | No | `[]` | A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`. |
-| `group_mappings` | `list` | No | `[]` | A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`. |
-| `defaults_file` | `str` | No | `"defaults.yaml"` | Path to the defaults YAML file. |
-| `group_file` | `str` | No | `"group.yaml"` | Path to the group YAML file. |
+| `address` | `str` | No | "http://localhost:8000" | The Infrahub URL to connect to. Defaults to "http://localhost:8000". |
+| `branch` | `str` | No | "main" | The Infrahub branch to use. Defaults to "main". |
+| `host_node` | `dict` | Yes |  | A dictionary defining the Infrahub Node kind that will be mapped to Nornir Hosts. Example: `{"kind": "InfraDevice"}` |
+| `schema_mappings` | `list` | Yes |  | A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`. |
+| `group_mappings` | `list` | Yes |  | A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`. |
+| `defaults_file` | `str` | No | "defaults.yaml" | Path to the defaults YAML file. Defaults to "defaults.yaml". |
+| `group_file` | `str` | No | "group.yaml" | Path to the group YAML file. Defaults to "group.yaml". |
 
 ### Examples
 
@@ -43,15 +44,12 @@ def main():
             "options": {
                 "address": "http://localhost:8000",  # Infrahub API URL
                 "token": "06438eb2-8019-4776-878c-0941b1f1d1ec",  # Infrahub API token
-                "host_node": {
-                    "kind": "InfraDevice",
-                    "include": ["primary_address", "platform", "site"],  # fetch relationship data
-                },
+                "host_node": {"kind": "InfraDevice"},  # Infrahub Node kind to map to Nornir Hosts
                 "schema_mappings": [
                     {"name": "hostname", "mapping": "primary_address.address"},
                     {"name": "platform", "mapping": "platform.nornir_platform"},
-                ],
-                "group_mappings": ["site.name"],
+                ],  # Mapping Nornir Host properties to Infrahub Node attributes
+                "group_mappings": ["site.name"],  # Create Nornir groups from Infrahub Node attributes
                 "group_file": "dummy.yml",  # Path to the group file
             },
         }

--- a/docs/docs/references/plugins/infrahub_inventory.mdx
+++ b/docs/docs/references/plugins/infrahub_inventory.mdx
@@ -19,8 +19,8 @@ from Infrahub Nodes.
 | `address` | `str` | No | "http://localhost:8000" | The Infrahub URL to connect to. Defaults to "http://localhost:8000". |
 | `branch` | `str` | No | "main" | The Infrahub branch to use. Defaults to "main". |
 | `host_node` | `dict` | Yes |  | A dictionary defining the Infrahub Node kind that will be mapped to Nornir Hosts. Example: `{"kind": "InfraDevice"}` |
-| `schema_mappings` | `list` | Yes |  | A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`. |
-| `group_mappings` | `list` | Yes |  | A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`. |
+| `schema_mappings` | `list` | No |  | A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`. |
+| `group_mappings` | `list` | No |  | A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`. |
 | `defaults_file` | `str` | No | "defaults.yaml" | Path to the defaults YAML file. Defaults to "defaults.yaml". |
 | `group_file` | `str` | No | "group.yaml" | Path to the group YAML file. Defaults to "group.yaml". |
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'references/plugins/infrahub_inventory',
         'references/plugins/artifact_tasks',
+        'references/plugins/file_object_tasks',
       ],
     }
   ]

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -139,8 +139,8 @@ class InfrahubInventory:
         address (str, optional): The Infrahub URL to connect to. Defaults to "http://localhost:8000".
         branch (str, optional): The Infrahub branch to use. Defaults to "main".
         host_node (dict): A dictionary defining the Infrahub Node kind that will be mapped to Nornir Hosts. Example: `{"kind": "InfraDevice"}`
-        schema_mappings (list): A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`.
-        group_mappings (list): A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`.
+        schema_mappings (list, optional): A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`.
+        group_mappings (list, optional): A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`.
         defaults_file (str, optional): Path to the defaults YAML file. Defaults to "defaults.yaml".
         group_file (str, optional): Path to the group YAML file. Defaults to "group.yaml".
 

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -145,7 +145,7 @@ class InfrahubInventory:
         group_file (str, optional): Path to the group YAML file. Defaults to "group.yaml".
 
     Example:
-        Basic usage of `InfrahubInventory` with Nornir.
+        Basic usage of `InfrahubInventory` with Nornir
 
         ```python
         from nornir import InitNornir

--- a/nornir_infrahub/plugins/tasks/__init__.py
+++ b/nornir_infrahub/plugins/tasks/__init__.py
@@ -1,7 +1,10 @@
 from .artifact import generate_artifacts, get_artifact, regenerate_host_artifact
+from .file_object import download_file_object, upload_file_object
 
 __all__ = (
-    "get_artifact",
+    "download_file_object",
     "generate_artifacts",
+    "get_artifact",
     "regenerate_host_artifact",
+    "upload_file_object",
 )

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -34,10 +33,6 @@ def _validate_file_object_kind(client: InfrahubClientSync, kind: str, branch: st
     if "CoreFileObject" not in getattr(schema, "inherit_from", []):
         raise ValueError(f"Kind '{kind}' does not inherit from CoreFileObject")
     return schema
-
-
-def _sha1(data: bytes) -> str:
-    return hashlib.sha1(data, usedforsecurity=False).hexdigest()
 
 
 def _resolve_upload_source(
@@ -274,15 +269,14 @@ def download_file_object(
             resolved_save_to = save_to_path
 
     changed = False
-    if resolved_save_to is not None and resolved_save_to.exists() and resolved_save_to.is_file():
-        local_checksum = _sha1(resolved_save_to.read_bytes())
-        if local_checksum == server_checksum:
-            content: bytes = resolved_save_to.read_bytes()
-        else:
-            content = obj.download_file()  # type: ignore[assignment]  # dest=None always returns bytes
-            resolved_save_to.parent.mkdir(parents=True, exist_ok=True)
-            resolved_save_to.write_bytes(content)
-            changed = True
+    if (
+        resolved_save_to is not None
+        and resolved_save_to.exists()
+        and resolved_save_to.is_file()
+        and server_checksum
+        and obj.matches_local_checksum(resolved_save_to)
+    ):
+        content: bytes = resolved_save_to.read_bytes()
     else:
         content = obj.download_file()  # type: ignore[assignment]  # dest=None always returns bytes
         if resolved_save_to is not None:

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -6,6 +6,7 @@ import base64
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from infrahub_sdk.exceptions import NodeNotFoundError
 from nornir.core.task import Result, Task
 from nornir_infrahub.utils import get_client
 
@@ -70,7 +71,7 @@ def _lookup_existing_object(
         if hfid:
             return client.get(kind=kind, hfid=hfid, branch=branch)
         return client.get(kind=kind, branch=branch, file_name__value=fallback_file_name)
-    except Exception:  # noqa: BLE001
+    except NodeNotFoundError:
         return None
 
 
@@ -106,7 +107,8 @@ def upload_file_object(
         object_id (str, optional): UUID of an existing object to update.
         hfid (list[str], optional): HFID components identifying an existing object.
         branch (str, optional): Target Infrahub branch. Defaults to the client's default branch.
-        **kwargs: Extra keyword arguments forwarded to ``client.create`` (e.g. ``allow_upsert``, ``timeout``).
+        **kwargs (Any, optional): Extra keyword arguments forwarded to ``client.create``
+            (e.g. ``allow_upsert``, ``timeout``).
 
     Returns:
         Result: A Nornir Result with ``changed`` indicating whether the object was
@@ -146,30 +148,44 @@ def upload_file_object(
     existing_obj = _lookup_existing_object(client, kind, object_id, hfid, upload_name, branch)
 
     if existing_obj:
+        attrs_changed = False
         for attr_name, attr_value in data.items():
             if attr_name in existing_obj._schema.attribute_names:
-                setattr(existing_obj, attr_name, attr_value)
+                current_attr = getattr(existing_obj, attr_name)
+                if getattr(current_attr, "value", current_attr) != attr_value:
+                    setattr(existing_obj, attr_name, attr_value)
+                    attrs_changed = True
 
         try:
             upload_result = existing_obj.upload_if_changed(source, upload_name)
         except Exception as exc:  # noqa: BLE001
             return Result(host=task.host, failed=True, result=str(exc))
 
-        if not upload_result.was_uploaded:
+        if upload_result.was_uploaded:
             return Result(
                 host=task.host,
                 failed=False,
-                changed=False,
+                changed=True,
                 object_id=str(existing_obj.id),
-                result=f"{kind} '{upload_name}' already up to date (checksum match)",
+                result=f"{kind} '{upload_name}' updated (checksum changed)",
+            )
+
+        if attrs_changed:
+            existing_obj.save()
+            return Result(
+                host=task.host,
+                failed=False,
+                changed=True,
+                object_id=str(existing_obj.id),
+                result=f"{kind} '{upload_name}' attributes updated (file unchanged)",
             )
 
         return Result(
             host=task.host,
             failed=False,
-            changed=True,
+            changed=False,
             object_id=str(existing_obj.id),
-            result=f"{kind} '{upload_name}' updated (checksum changed)",
+            result=f"{kind} '{upload_name}' already up to date (checksum match)",
         )
 
     try:

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -44,8 +44,9 @@ def _resolve_upload_source(
     file_path: str | Path | None,
     content: bytes | None,
     file_name: str | None,
-) -> tuple[bytes, str, Path | None]:
-    # Returns (payload_bytes, upload_name, path_or_none); raises ValueError on bad args.
+) -> tuple[bytes | Path, str]:
+    # Returns (source, upload_name); raises ValueError on bad args.
+    # source is a Path (streamed by the SDK) or raw bytes.
     if (file_path is None) == (content is None):
         raise ValueError("Exactly one of 'file_path' or 'content' must be provided")
 
@@ -53,18 +54,11 @@ def _resolve_upload_source(
         path = Path(file_path)
         if not path.exists():
             raise ValueError(f"file_path '{file_path}' does not exist")
-        return path.read_bytes(), path.name, path
+        return path, path.name
 
     if not file_name:
         raise ValueError("'file_name' is required when using 'content'")
-    return content, file_name, None  # type: ignore[return-value]
-
-
-def _attach_content(obj: Any, path: Path | None, payload: bytes, name: str) -> None:
-    if path is not None:
-        obj.upload_from_path(path)
-    else:
-        obj.upload_from_bytes(content=payload, name=name)
+    return content, file_name  # type: ignore[return-value]
 
 
 def _lookup_existing_object(
@@ -142,7 +136,7 @@ def upload_file_object(
         ```
     """
     try:
-        payload, upload_name, path = _resolve_upload_source(file_path, content, file_name)
+        source, upload_name = _resolve_upload_source(file_path, content, file_name)
     except ValueError as exc:
         return Result(host=task.host, failed=True, result=str(exc))
 
@@ -157,7 +151,16 @@ def upload_file_object(
     existing_obj = _lookup_existing_object(client, kind, object_id, hfid, upload_name, branch)
 
     if existing_obj:
-        if _sha1(payload) == existing_obj.checksum.value:
+        for attr_name, attr_value in data.items():
+            if attr_name in existing_obj._schema.attribute_names:
+                setattr(existing_obj, attr_name, attr_value)
+
+        try:
+            upload_result = existing_obj.upload_if_changed(source, upload_name)
+        except Exception as exc:  # noqa: BLE001
+            return Result(host=task.host, failed=True, result=str(exc))
+
+        if not upload_result.was_uploaded:
             return Result(
                 host=task.host,
                 failed=False,
@@ -165,13 +168,6 @@ def upload_file_object(
                 object_id=str(existing_obj.id),
                 result=f"{kind} '{upload_name}' already up to date (checksum match)",
             )
-
-        for attr_name, attr_value in data.items():
-            if attr_name in existing_obj._schema.attribute_names:
-                setattr(existing_obj, attr_name, attr_value)
-
-        _attach_content(existing_obj, path, payload, upload_name)
-        existing_obj.save()
 
         return Result(
             host=task.host,
@@ -183,8 +179,7 @@ def upload_file_object(
 
     try:
         new_obj = client.create(kind=kind, branch=branch, data=data, **kwargs)
-        _attach_content(new_obj, path, payload, upload_name)
-        new_obj.save()
+        new_obj.upload_if_changed(source, upload_name)
     except Exception as exc:  # noqa: BLE001
         return Result(host=task.host, failed=True, result=str(exc))
 

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -72,7 +73,14 @@ def _lookup_existing_object(
             return client.get(kind=kind, hfid=hfid, branch=branch)
         return client.get(kind=kind, branch=branch, file_name__value=fallback_file_name)
     except NodeNotFoundError:
+        if object_id is not None:
+            raise
         return None
+    except IndexError as exc:
+        raise ValueError(
+            f"Multiple {kind} objects share file_name='{fallback_file_name}'; "
+            "specify object_id or hfid to disambiguate."
+        ) from exc
 
 
 def upload_file_object(
@@ -103,12 +111,16 @@ def upload_file_object(
         file_path (str | Path, optional): Filesystem path to the file to upload.
         content (bytes, optional): Raw file content to upload. Requires ``file_name``.
         file_name (str, optional): File name to associate with ``content``. Ignored when ``file_path`` is used.
-        data (dict, optional): Additional object attributes to set on create or update.
+        data (dict, optional): Additional object fields. On create, this is forwarded to
+            ``client.create`` (attributes and relationships). On update, only attribute
+            keys are applied; passing a relationship or unknown key fails the task.
         object_id (str, optional): UUID of an existing object to update.
         hfid (list[str], optional): HFID components identifying an existing object.
         branch (str, optional): Target Infrahub branch. Defaults to the client's default branch.
         **kwargs (Any, optional): Extra keyword arguments forwarded to ``client.create``
-            (e.g. ``allow_upsert``, ``timeout``).
+            (e.g. ``allow_upsert``, ``timeout``). Applies only on the create path;
+            the update path does not call ``client.create``, so these are not used
+            when updating an existing object.
 
     Returns:
         Result: A Nornir Result with ``changed`` indicating whether the object was
@@ -145,16 +157,41 @@ def upload_file_object(
         return Result(host=task.host, failed=True, result=str(exc))
 
     data = data or {}
-    existing_obj = _lookup_existing_object(client, kind, object_id, hfid, upload_name, branch)
+    try:
+        existing_obj = _lookup_existing_object(client, kind, object_id, hfid, upload_name, branch)
+    except NodeNotFoundError as exc:
+        return Result(
+            host=task.host,
+            failed=True,
+            result=f"{kind} with id={object_id!r} not found: {exc}",
+        )
+    except ValueError as exc:
+        return Result(host=task.host, failed=True, result=str(exc))
 
     if existing_obj:
         attrs_changed = False
-        for attr_name, attr_value in data.items():
-            if attr_name in existing_obj._schema.attribute_names:
-                current_attr = getattr(existing_obj, attr_name)
-                if getattr(current_attr, "value", current_attr) != attr_value:
-                    setattr(existing_obj, attr_name, attr_value)
+        for key, value in data.items():
+            if key in existing_obj._schema.attribute_names:
+                current_attr = getattr(existing_obj, key)
+                if getattr(current_attr, "value", current_attr) != value:
+                    setattr(existing_obj, key, value)
                     attrs_changed = True
+            elif key in existing_obj._schema.relationship_names:
+                return Result(
+                    host=task.host,
+                    failed=True,
+                    result=(
+                        f"Cannot update relationship '{key}' on existing {kind} via `data`; "
+                        "the `data` parameter only updates attributes on existing objects. "
+                        "Use the infrahub-sdk directly to change relationships."
+                    ),
+                )
+            else:
+                return Result(
+                    host=task.host,
+                    failed=True,
+                    result=f"Unknown key '{key}' in `data` for {kind}; not an attribute or relationship.",
+                )
 
         try:
             upload_result = existing_obj.upload_if_changed(source, upload_name)
@@ -222,6 +259,12 @@ def download_file_object(
     server-side checksum, the download is skipped and ``changed`` is ``False``
     (idempotent, similar to ``nornir_utils.plugins.tasks.files.write_file``).
 
+    Note: The downloaded content is held in memory and embedded as base64 in the
+    Nornir ``Result``. Nornir aggregates results across hosts, so downloading
+    large files across many hosts can be heavy. For large payloads, prefer
+    ``save_to`` and ignore the ``binary``/``text`` fields, or call the
+    infrahub-sdk download API directly.
+
     Args:
         task (Task): The Nornir task instance containing host-related data.
         kind (str): The schema kind that inherits from CoreFileObject.
@@ -279,7 +322,8 @@ def download_file_object(
     resolved_save_to: Path | None = None
     if save_to is not None:
         save_to_path = Path(save_to)
-        if str(save_to).endswith("/") or save_to_path.is_dir():
+        save_to_str = str(save_to)
+        if save_to_str.endswith(("/", os.sep)) or save_to_path.is_dir():
             resolved_save_to = save_to_path / obj.file_name.value
         else:
             resolved_save_to = save_to_path

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -1,0 +1,258 @@
+"""CoreFileObject management tasks"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from nornir.core.task import Result, Task
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClientSync
+    from infrahub_sdk.schema import NodeSchemaAPI
+
+TEXT_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "application/json",
+        "application/yaml",
+        "application/x-yaml",
+        "application/hcl",
+        "application/graphql",
+        "application/xml",
+    }
+)
+
+
+def _get_client(task: Task) -> InfrahubClientSync:
+    # Extract the InfrahubClientSync from the Nornir task's host data.
+    node = task.host.data["InfrahubNode"]
+    return node._client
+
+
+def _validate_file_object_kind(client: InfrahubClientSync, kind: str, branch: str | None = None) -> NodeSchemaAPI:  # type: ignore[return-type]  # SDK returns union of schema types
+    # Fetch schema and verify it inherits from CoreFileObject. Raises ValueError if not.
+    schema = client.schema.get(kind=kind, branch=branch)
+    if "CoreFileObject" not in getattr(schema, "inherit_from", []):
+        raise ValueError(f"Kind '{kind}' does not inherit from CoreFileObject")
+    return schema
+
+
+def upload_file_object(
+    task: Task,
+    kind: str,
+    file_path: str,
+    data: dict[str, Any] | None = None,
+    node_id: str | None = None,
+    hfid: list[str] | None = None,
+    branch: str | None = None,
+) -> Result:
+    """
+    Uploads a local file to an Infrahub CoreFileObject node.
+
+    Creates the node if it does not exist, or updates it if the file content
+    has changed (SHA-1 checksum comparison).  When the local file is identical
+    to the one stored on the server the upload is skipped (idempotent).
+
+    Args:
+        task (Task): The Nornir task instance containing host-related data.
+        kind (str): The schema kind that inherits from CoreFileObject.
+        file_path (str): Local filesystem path to the file to upload.
+        data (dict, optional): Additional node attributes to set on create or update.
+        node_id (str, optional): UUID of an existing node to update.
+        hfid (list[str], optional): HFID components identifying an existing node.
+        branch (str, optional): Target Infrahub branch. Defaults to the client's default branch.
+
+    Returns:
+        Result: A Nornir Result with ``changed`` indicating whether the node was
+            created or updated, ``node_id`` with the UUID, and a descriptive
+            ``result`` message.
+
+    Raises:
+        ValueError: If *kind* does not inherit from CoreFileObject.
+
+    Example:
+        Upload a contract PDF to a CoreFileObject node
+
+        ```python
+        from nornir_infrahub.plugins.tasks import upload_file_object
+
+        result = nr.run(
+            task=upload_file_object,
+            kind="NetworkCircuitContract",
+            file_path="/path/to/contract.pdf",
+            data={"contract_start": "2026-01-01"},
+        )
+        ```
+    """
+    path = Path(file_path)
+    if not path.exists():
+        return Result(host=task.host, failed=True, result=f"file_path '{file_path}' does not exist")
+
+    client = _get_client(task)
+
+    try:
+        _validate_file_object_kind(client, kind, branch)
+    except ValueError as exc:
+        return Result(host=task.host, failed=True, result=str(exc))
+
+    data = data or {}
+
+    # Look up existing node
+    existing_node = None
+    try:
+        if node_id:
+            existing_node = client.get(kind=kind, id=node_id, branch=branch)
+        elif hfid:
+            existing_node = client.get(kind=kind, hfid=hfid, branch=branch)
+        else:
+            # Fall back to file_name filter
+            file_name = path.name
+            existing_node = client.get(kind=kind, branch=branch, file_name__value=file_name)
+    except Exception:  # noqa: BLE001
+        existing_node = None
+
+    if existing_node:
+        # Compare checksums
+        local_checksum = hashlib.sha1(path.read_bytes(), usedforsecurity=False).hexdigest()
+        server_checksum = existing_node.checksum.value
+
+        if local_checksum == server_checksum:
+            return Result(
+                host=task.host,
+                failed=False,
+                changed=False,
+                node_id=str(existing_node.id),
+                result=f"{kind} '{path.name}' already up to date (checksum match)",
+            )
+
+        # Update: re-upload changed file
+        for attr_name, attr_value in data.items():
+            if attr_name in existing_node._schema.attribute_names:
+                setattr(existing_node, attr_name, attr_value)
+
+        existing_node.upload_from_path(path)
+        existing_node.save()
+
+        return Result(
+            host=task.host,
+            failed=False,
+            changed=True,
+            node_id=str(existing_node.id),
+            result=f"{kind} '{path.name}' updated (checksum changed)",
+        )
+
+    # Create new node
+    try:
+        new_node = client.create(kind=kind, branch=branch, data=data)
+        new_node.upload_from_path(path)
+        new_node.save()
+    except Exception as exc:  # noqa: BLE001
+        return Result(host=task.host, failed=True, result=str(exc))
+
+    return Result(
+        host=task.host,
+        failed=False,
+        changed=True,
+        node_id=str(new_node.id),
+        result=f"{kind} '{path.name}' created",
+    )
+
+
+def download_file_object(
+    task: Task,
+    kind: str,
+    node_id: str | None = None,
+    hfid: list[str] | None = None,
+    dest: str | None = None,
+    branch: str | None = None,
+) -> Result:
+    """
+    Downloads file content from an Infrahub CoreFileObject node.
+
+    Returns the file content as base64-encoded binary data, with a UTF-8
+    text representation for text MIME types.  Optionally saves the file
+    to a local destination path.
+
+    Args:
+        task (Task): The Nornir task instance containing host-related data.
+        kind (str): The schema kind that inherits from CoreFileObject.
+        node_id (str, optional): UUID of the node to download from.
+        hfid (list[str], optional): HFID components identifying the node.
+        dest (str, optional): Local path to save the downloaded file. Directories get the original file name appended.
+        branch (str, optional): Target Infrahub branch. Defaults to the client's default branch.
+
+    Returns:
+        Result: A Nornir Result containing ``binary`` (base64 string),
+            ``text`` (UTF-8 string or None), ``file_name``, ``file_type``,
+            ``file_size``, ``checksum``, ``node_id``, and ``dest``.
+
+    Raises:
+        ValueError: If *kind* does not inherit from CoreFileObject.
+
+    Example:
+        Download a file from a CoreFileObject node
+
+        ```python
+        from nornir_infrahub.plugins.tasks import download_file_object
+
+        result = nr.run(
+            task=download_file_object,
+            kind="NetworkCircuitContract",
+            hfid=["contract-2026"],
+        )
+        ```
+    """
+    if not node_id and not hfid:
+        return Result(host=task.host, failed=True, result="One of 'node_id' or 'hfid' is required")
+
+    if node_id and hfid:
+        return Result(host=task.host, failed=True, result="'node_id' and 'hfid' are mutually exclusive")
+
+    client = _get_client(task)
+
+    try:
+        _validate_file_object_kind(client, kind, branch)
+    except ValueError as exc:
+        return Result(host=task.host, failed=True, result=str(exc))
+
+    try:
+        if node_id:
+            node = client.get(kind=kind, id=node_id, branch=branch)
+        else:
+            node = client.get(kind=kind, hfid=hfid, branch=branch)
+    except Exception as exc:  # noqa: BLE001
+        return Result(host=task.host, failed=True, result=f"Node not found: {exc}")
+
+    content: bytes = node.download_file()  # type: ignore[assignment]  # dest=None always returns bytes
+
+    # Write to dest if requested
+    resolved_dest: str | None = None
+    if dest is not None:
+        dest_path = Path(dest)
+        if dest.endswith("/") or dest_path.is_dir():
+            resolved_dest = str(dest_path / node.file_name.value)
+        else:
+            resolved_dest = str(dest_path)
+        Path(resolved_dest).parent.mkdir(parents=True, exist_ok=True)
+        Path(resolved_dest).write_bytes(content)
+
+    file_type = node.file_type.value
+    is_text = file_type in TEXT_MIME_TYPES
+
+    return Result(
+        host=task.host,
+        failed=False,
+        binary=base64.b64encode(content).decode("ascii"),
+        text=content.decode("utf-8", errors="replace") if is_text else None,
+        file_name=node.file_name.value,
+        file_type=file_type,
+        file_size=node.file_size.value,
+        checksum=node.checksum.value,
+        node_id=str(node.id),
+        dest=resolved_dest,
+    )

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from nornir.core.task import Result, Task
+from nornir_infrahub.utils import get_client
 
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClientSync
@@ -28,55 +29,106 @@ TEXT_MIME_TYPES: frozenset[str] = frozenset(
 )
 
 
-def _get_client(task: Task) -> InfrahubClientSync:
-    # Extract the InfrahubClientSync from the Nornir task's host data.
-    node = task.host.data["InfrahubNode"]
-    return node._client
-
-
 def _validate_file_object_kind(client: InfrahubClientSync, kind: str, branch: str | None = None) -> NodeSchemaAPI:  # type: ignore[return-type]  # SDK returns union of schema types
-    # Fetch schema and verify it inherits from CoreFileObject. Raises ValueError if not.
     schema = client.schema.get(kind=kind, branch=branch)
     if "CoreFileObject" not in getattr(schema, "inherit_from", []):
         raise ValueError(f"Kind '{kind}' does not inherit from CoreFileObject")
     return schema
 
 
+def _sha1(data: bytes) -> str:
+    return hashlib.sha1(data, usedforsecurity=False).hexdigest()
+
+
+def _resolve_upload_source(
+    file_path: str | Path | None,
+    content: bytes | None,
+    file_name: str | None,
+) -> tuple[bytes, str, Path | None]:
+    # Returns (payload_bytes, upload_name, path_or_none); raises ValueError on bad args.
+    if (file_path is None) == (content is None):
+        raise ValueError("Exactly one of 'file_path' or 'content' must be provided")
+
+    if file_path is not None:
+        path = Path(file_path)
+        if not path.exists():
+            raise ValueError(f"file_path '{file_path}' does not exist")
+        return path.read_bytes(), path.name, path
+
+    if not file_name:
+        raise ValueError("'file_name' is required when using 'content'")
+    return content, file_name, None  # type: ignore[return-value]
+
+
+def _attach_content(obj: Any, path: Path | None, payload: bytes, name: str) -> None:
+    if path is not None:
+        obj.upload_from_path(path)
+    else:
+        obj.upload_from_bytes(content=payload, name=name)
+
+
+def _lookup_existing_object(
+    client: InfrahubClientSync,
+    kind: str,
+    object_id: str | None,
+    hfid: list[str] | None,
+    fallback_file_name: str,
+    branch: str | None,
+) -> Any:
+    try:
+        if object_id:
+            return client.get(kind=kind, id=object_id, branch=branch)
+        if hfid:
+            return client.get(kind=kind, hfid=hfid, branch=branch)
+        return client.get(kind=kind, branch=branch, file_name__value=fallback_file_name)
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def upload_file_object(
     task: Task,
     kind: str,
-    file_path: str,
+    file_path: str | Path | None = None,
+    content: bytes | None = None,
+    file_name: str | None = None,
     data: dict[str, Any] | None = None,
-    node_id: str | None = None,
+    object_id: str | None = None,
     hfid: list[str] | None = None,
     branch: str | None = None,
+    **kwargs: Any,
 ) -> Result:
     """
-    Uploads a local file to an Infrahub CoreFileObject node.
+    Uploads a file to an Infrahub CoreFileObject object.
 
-    Creates the node if it does not exist, or updates it if the file content
-    has changed (SHA-1 checksum comparison).  When the local file is identical
+    Creates the object if it does not exist, or updates it if the file content
+    has changed (SHA-1 checksum comparison).  When the local content is identical
     to the one stored on the server the upload is skipped (idempotent).
+
+    Provide either ``file_path`` (to upload a file from disk) or ``content`` with
+    ``file_name`` (to upload raw bytes).
 
     Args:
         task (Task): The Nornir task instance containing host-related data.
         kind (str): The schema kind that inherits from CoreFileObject.
-        file_path (str): Local filesystem path to the file to upload.
-        data (dict, optional): Additional node attributes to set on create or update.
-        node_id (str, optional): UUID of an existing node to update.
-        hfid (list[str], optional): HFID components identifying an existing node.
+        file_path (str | Path, optional): Filesystem path to the file to upload.
+        content (bytes, optional): Raw file content to upload. Requires ``file_name``.
+        file_name (str, optional): File name to associate with ``content``. Ignored when ``file_path`` is used.
+        data (dict, optional): Additional object attributes to set on create or update.
+        object_id (str, optional): UUID of an existing object to update.
+        hfid (list[str], optional): HFID components identifying an existing object.
         branch (str, optional): Target Infrahub branch. Defaults to the client's default branch.
+        **kwargs: Extra keyword arguments forwarded to ``client.create`` (e.g. ``allow_upsert``, ``timeout``).
 
     Returns:
-        Result: A Nornir Result with ``changed`` indicating whether the node was
-            created or updated, ``node_id`` with the UUID, and a descriptive
+        Result: A Nornir Result with ``changed`` indicating whether the object was
+            created or updated, ``object_id`` with the UUID, and a descriptive
             ``result`` message.
 
     Raises:
-        ValueError: If *kind* does not inherit from CoreFileObject.
+        ValueError: If *kind* does not inherit from CoreFileObject or arguments are inconsistent.
 
     Example:
-        Upload a contract PDF to a CoreFileObject node
+        Upload a contract PDF to a CoreFileObject object
 
         ```python
         from nornir_infrahub.plugins.tasks import upload_file_object
@@ -89,11 +141,12 @@ def upload_file_object(
         )
         ```
     """
-    path = Path(file_path)
-    if not path.exists():
-        return Result(host=task.host, failed=True, result=f"file_path '{file_path}' does not exist")
+    try:
+        payload, upload_name, path = _resolve_upload_source(file_path, content, file_name)
+    except ValueError as exc:
+        return Result(host=task.host, failed=True, result=str(exc))
 
-    client = _get_client(task)
+    client = get_client(task)
 
     try:
         _validate_file_object_kind(client, kind, branch)
@@ -101,56 +154,37 @@ def upload_file_object(
         return Result(host=task.host, failed=True, result=str(exc))
 
     data = data or {}
+    existing_obj = _lookup_existing_object(client, kind, object_id, hfid, upload_name, branch)
 
-    # Look up existing node
-    existing_node = None
-    try:
-        if node_id:
-            existing_node = client.get(kind=kind, id=node_id, branch=branch)
-        elif hfid:
-            existing_node = client.get(kind=kind, hfid=hfid, branch=branch)
-        else:
-            # Fall back to file_name filter
-            file_name = path.name
-            existing_node = client.get(kind=kind, branch=branch, file_name__value=file_name)
-    except Exception:  # noqa: BLE001
-        existing_node = None
-
-    if existing_node:
-        # Compare checksums
-        local_checksum = hashlib.sha1(path.read_bytes(), usedforsecurity=False).hexdigest()
-        server_checksum = existing_node.checksum.value
-
-        if local_checksum == server_checksum:
+    if existing_obj:
+        if _sha1(payload) == existing_obj.checksum.value:
             return Result(
                 host=task.host,
                 failed=False,
                 changed=False,
-                node_id=str(existing_node.id),
-                result=f"{kind} '{path.name}' already up to date (checksum match)",
+                object_id=str(existing_obj.id),
+                result=f"{kind} '{upload_name}' already up to date (checksum match)",
             )
 
-        # Update: re-upload changed file
         for attr_name, attr_value in data.items():
-            if attr_name in existing_node._schema.attribute_names:
-                setattr(existing_node, attr_name, attr_value)
+            if attr_name in existing_obj._schema.attribute_names:
+                setattr(existing_obj, attr_name, attr_value)
 
-        existing_node.upload_from_path(path)
-        existing_node.save()
+        _attach_content(existing_obj, path, payload, upload_name)
+        existing_obj.save()
 
         return Result(
             host=task.host,
             failed=False,
             changed=True,
-            node_id=str(existing_node.id),
-            result=f"{kind} '{path.name}' updated (checksum changed)",
+            object_id=str(existing_obj.id),
+            result=f"{kind} '{upload_name}' updated (checksum changed)",
         )
 
-    # Create new node
     try:
-        new_node = client.create(kind=kind, branch=branch, data=data)
-        new_node.upload_from_path(path)
-        new_node.save()
+        new_obj = client.create(kind=kind, branch=branch, data=data, **kwargs)
+        _attach_content(new_obj, path, payload, upload_name)
+        new_obj.save()
     except Exception as exc:  # noqa: BLE001
         return Result(host=task.host, failed=True, result=str(exc))
 
@@ -158,44 +192,50 @@ def upload_file_object(
         host=task.host,
         failed=False,
         changed=True,
-        node_id=str(new_node.id),
-        result=f"{kind} '{path.name}' created",
+        object_id=str(new_obj.id),
+        result=f"{kind} '{upload_name}' created",
     )
 
 
 def download_file_object(
     task: Task,
     kind: str,
-    node_id: str | None = None,
+    object_id: str | None = None,
     hfid: list[str] | None = None,
-    dest: str | None = None,
+    save_to: str | Path | None = None,
     branch: str | None = None,
 ) -> Result:
     """
-    Downloads file content from an Infrahub CoreFileObject node.
+    Downloads file content from an Infrahub CoreFileObject object.
 
     Returns the file content as base64-encoded binary data, with a UTF-8
     text representation for text MIME types.  Optionally saves the file
-    to a local destination path.
+    to a local path.
+
+    When ``save_to`` points to an existing file whose SHA-1 matches the
+    server-side checksum, the download is skipped and ``changed`` is ``False``
+    (idempotent, similar to ``nornir_utils.plugins.tasks.files.write_file``).
 
     Args:
         task (Task): The Nornir task instance containing host-related data.
         kind (str): The schema kind that inherits from CoreFileObject.
-        node_id (str, optional): UUID of the node to download from.
-        hfid (list[str], optional): HFID components identifying the node.
-        dest (str, optional): Local path to save the downloaded file. Directories get the original file name appended.
+        object_id (str, optional): UUID of the object to download from.
+        hfid (list[str], optional): HFID components identifying the object.
+        save_to (str | Path, optional): Local path where the downloaded file should be written.
+            A directory receives the original file name; an explicit path is used as-is.
         branch (str, optional): Target Infrahub branch. Defaults to the client's default branch.
 
     Returns:
         Result: A Nornir Result containing ``binary`` (base64 string),
             ``text`` (UTF-8 string or None), ``file_name``, ``file_type``,
-            ``file_size``, ``checksum``, ``node_id``, and ``dest``.
+            ``file_size``, ``checksum``, ``object_id``, ``save_to``, and
+            ``changed`` (True only when a local file was created or overwritten).
 
     Raises:
         ValueError: If *kind* does not inherit from CoreFileObject.
 
     Example:
-        Download a file from a CoreFileObject node
+        Download a file from a CoreFileObject object
 
         ```python
         from nornir_infrahub.plugins.tasks import download_file_object
@@ -207,13 +247,13 @@ def download_file_object(
         )
         ```
     """
-    if not node_id and not hfid:
-        return Result(host=task.host, failed=True, result="One of 'node_id' or 'hfid' is required")
+    if not object_id and not hfid:
+        return Result(host=task.host, failed=True, result="One of 'object_id' or 'hfid' is required")
 
-    if node_id and hfid:
-        return Result(host=task.host, failed=True, result="'node_id' and 'hfid' are mutually exclusive")
+    if object_id and hfid:
+        return Result(host=task.host, failed=True, result="'object_id' and 'hfid' are mutually exclusive")
 
-    client = _get_client(task)
+    client = get_client(task)
 
     try:
         _validate_file_object_kind(client, kind, branch)
@@ -221,38 +261,53 @@ def download_file_object(
         return Result(host=task.host, failed=True, result=str(exc))
 
     try:
-        if node_id:
-            node = client.get(kind=kind, id=node_id, branch=branch)
+        if object_id:
+            obj = client.get(kind=kind, id=object_id, branch=branch)
         else:
-            node = client.get(kind=kind, hfid=hfid, branch=branch)
+            obj = client.get(kind=kind, hfid=hfid, branch=branch)
     except Exception as exc:  # noqa: BLE001
-        return Result(host=task.host, failed=True, result=f"Node not found: {exc}")
+        return Result(host=task.host, failed=True, result=f"Object not found: {exc}")
 
-    content: bytes = node.download_file()  # type: ignore[assignment]  # dest=None always returns bytes
+    server_checksum = obj.checksum.value
 
-    # Write to dest if requested
-    resolved_dest: str | None = None
-    if dest is not None:
-        dest_path = Path(dest)
-        if dest.endswith("/") or dest_path.is_dir():
-            resolved_dest = str(dest_path / node.file_name.value)
+    resolved_save_to: Path | None = None
+    if save_to is not None:
+        save_to_path = Path(save_to)
+        if str(save_to).endswith("/") or save_to_path.is_dir():
+            resolved_save_to = save_to_path / obj.file_name.value
         else:
-            resolved_dest = str(dest_path)
-        Path(resolved_dest).parent.mkdir(parents=True, exist_ok=True)
-        Path(resolved_dest).write_bytes(content)
+            resolved_save_to = save_to_path
 
-    file_type = node.file_type.value
+    changed = False
+    if resolved_save_to is not None and resolved_save_to.exists() and resolved_save_to.is_file():
+        local_checksum = _sha1(resolved_save_to.read_bytes())
+        if local_checksum == server_checksum:
+            content: bytes = resolved_save_to.read_bytes()
+        else:
+            content = obj.download_file()  # type: ignore[assignment]  # dest=None always returns bytes
+            resolved_save_to.parent.mkdir(parents=True, exist_ok=True)
+            resolved_save_to.write_bytes(content)
+            changed = True
+    else:
+        content = obj.download_file()  # type: ignore[assignment]  # dest=None always returns bytes
+        if resolved_save_to is not None:
+            resolved_save_to.parent.mkdir(parents=True, exist_ok=True)
+            resolved_save_to.write_bytes(content)
+            changed = True
+
+    file_type = obj.file_type.value
     is_text = file_type in TEXT_MIME_TYPES
 
     return Result(
         host=task.host,
         failed=False,
+        changed=changed,
         binary=base64.b64encode(content).decode("ascii"),
         text=content.decode("utf-8", errors="replace") if is_text else None,
-        file_name=node.file_name.value,
+        file_name=obj.file_name.value,
         file_type=file_type,
-        file_size=node.file_size.value,
-        checksum=node.checksum.value,
-        node_id=str(node.id),
-        dest=resolved_dest,
+        file_size=obj.file_size.value,
+        checksum=server_checksum,
+        object_id=str(obj.id),
+        save_to=str(resolved_save_to) if resolved_save_to is not None else None,
     )

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -226,7 +226,14 @@ def upload_file_object(
         )
 
     try:
-        new_obj = client.create(kind=kind, branch=branch, data=data, **kwargs)
+        create_data = dict(data)
+        if not create_data and not kwargs:
+            # client.create requires at least one field or keyword. Seed file_name
+            # from the source so a bare upload (no data, no kwargs) succeeds;
+            # upload_if_changed() refreshes file_name from the actual content
+            # before the node is saved.
+            create_data["file_name"] = {"value": upload_name}
+        new_obj = client.create(kind=kind, branch=branch, data=create_data, **kwargs)
         new_obj.upload_if_changed(source, upload_name)
     except Exception as exc:  # noqa: BLE001
         return Result(host=task.host, failed=True, result=str(exc))

--- a/nornir_infrahub/plugins/tasks/file_object.py
+++ b/nornir_infrahub/plugins/tasks/file_object.py
@@ -30,11 +30,11 @@ TEXT_MIME_TYPES: frozenset[str] = frozenset(
 )
 
 
-def _validate_file_object_kind(client: InfrahubClientSync, kind: str, branch: str | None = None) -> NodeSchemaAPI:  # type: ignore[return-type]  # SDK returns union of schema types
+def _validate_file_object_kind(client: InfrahubClientSync, kind: str, branch: str | None = None) -> NodeSchemaAPI:
     schema = client.schema.get(kind=kind, branch=branch)
     if "CoreFileObject" not in getattr(schema, "inherit_from", []):
         raise ValueError(f"Kind '{kind}' does not inherit from CoreFileObject")
-    return schema
+    return schema  # type: ignore[return-type]  # SDK returns union of schema types
 
 
 def _resolve_upload_source(

--- a/nornir_infrahub/utils.py
+++ b/nornir_infrahub/utils.py
@@ -1,0 +1,14 @@
+"""Shared helpers for Nornir Infrahub plugins."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClientSync
+    from nornir.core.task import Task
+
+
+def get_client(task: Task) -> InfrahubClientSync:
+    """Return the ``InfrahubClientSync`` attached to the Nornir host by the inventory plugin."""
+    return task.host.data["InfrahubNode"]._client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,6 @@ markers = ["integration: marks tests as integration tests (requires Docker)"]
 unresolved-import = "ignore"
 # Infrahub SDK uses dynamic types that ty cannot fully understand without plugin support
 invalid-argument-type = "ignore"
-invalid-return-type = "ignore"
-invalid-assignment = "ignore"
 possibly-missing-attribute = "ignore"
 
 [tool.pylint.general]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ known-third-party = ["nornir_infrahub"]
 "tasks.py" = ["PLC0415"]  # Allow deferred imports in invoke tasks
 "tests/**" = ["PLC0415", "PLR2004"]  # Allow deferred imports and magic numbers in tests
 "nornir_infrahub/plugins/tasks/**" = [
+    "PLR0911", # Nornir task functions return a failed Result at each guard
     "PLR0912", # Nornir task functions naturally branch on optional args
     "PLR0913", # Nornir task functions require many parameters
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,10 @@ known-third-party = ["nornir_infrahub"]
 [tool.ruff.lint.per-file-ignores]
 "tasks.py" = ["PLC0415"]  # Allow deferred imports in invoke tasks
 "tests/**" = ["PLC0415", "PLR2004"]  # Allow deferred imports and magic numbers in tests
-"nornir_infrahub/plugins/tasks/**" = ["PLR0913"]  # Nornir task functions require many parameters
+"nornir_infrahub/plugins/tasks/**" = [
+    "PLR0912", # Nornir task functions naturally branch on optional args
+    "PLR0913", # Nornir task functions require many parameters
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "infrahub-sdk>=1.17.0,<2",
+    "infrahub-sdk>=1.19.0,<2",
     "ruamel-yaml>=0.18.17,<0.20",
     "nornir>=3.5.0,<4",
     "nornir-utils>=0.2.0,<0.3",
@@ -71,6 +71,8 @@ markers = ["integration: marks tests as integration tests (requires Docker)"]
 unresolved-import = "ignore"
 # Infrahub SDK uses dynamic types that ty cannot fully understand without plugin support
 invalid-argument-type = "ignore"
+invalid-return-type = "ignore"
+invalid-assignment = "ignore"
 possibly-missing-attribute = "ignore"
 
 [tool.pylint.general]
@@ -160,6 +162,7 @@ known-third-party = ["nornir_infrahub"]
 [tool.ruff.lint.per-file-ignores]
 "tasks.py" = ["PLC0415"]  # Allow deferred imports in invoke tasks
 "tests/**" = ["PLC0415", "PLR2004"]  # Allow deferred imports and magic numbers in tests
+"nornir_infrahub/plugins/tasks/**" = ["PLR0913"]  # Nornir task functions require many parameters
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "infrahub-sdk>=1.19.0,<2",
+    "infrahub-sdk>=1.20.1,<2",
     "ruamel-yaml>=0.18.17,<0.20",
     "nornir>=3.5.0,<4",
     "nornir-utils>=0.2.0,<0.3",

--- a/tests/integration/test_file_object.py
+++ b/tests/integration/test_file_object.py
@@ -1,0 +1,196 @@
+"""Integration tests for CoreFileObject upload/download tasks."""
+
+import base64
+
+import pytest
+from infrahub_sdk import Config, InfrahubClientSync
+from nornir_infrahub.plugins.tasks.file_object import (
+    download_file_object,
+    upload_file_object,
+)
+
+from .conftest import TEST_TOKEN, NornirInfrahubIntegration
+
+FILE_OBJECT_SCHEMA = {
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "TestFile",
+            "namespace": "Testing",
+            "inherit_from": ["CoreFileObject"],
+            "attributes": [
+                {"name": "label", "kind": "Text", "optional": True},
+            ],
+        },
+    ],
+}
+
+
+class _NodeWrapper:
+    def __init__(self, client: InfrahubClientSync) -> None:
+        self._client = client
+
+
+class _FakeHost:
+    def __init__(self, client: InfrahubClientSync) -> None:
+        self.data = {"InfrahubNode": _NodeWrapper(client)}
+
+
+class _FakeTask:
+    """Minimal Task stand-in: file_object tasks only read ``task.host.data['InfrahubNode']._client``."""
+
+    def __init__(self, client: InfrahubClientSync) -> None:
+        self.host = _FakeHost(client)
+
+
+@pytest.mark.integration
+class TestFileObjectTasks(NornirInfrahubIntegration):
+    @pytest.fixture(scope="class", autouse=True)
+    def file_object_schema(self, infrahub_address: str, bootstrap: None) -> None:  # noqa: ARG002
+        # Layer the CoreFileObject-inheriting kind onto the conftest's base bootstrap.
+        client = InfrahubClientSync(
+            config=Config(api_token=TEST_TOKEN),
+            address=infrahub_address,
+        )
+        client.schema.load(schemas=[FILE_OBJECT_SCHEMA], wait_until_converged=True)
+
+    @pytest.fixture(scope="class")
+    def client(self, infrahub_address: str) -> InfrahubClientSync:
+        return InfrahubClientSync(
+            config=Config(api_token=TEST_TOKEN),
+            address=infrahub_address,
+        )
+
+    @pytest.fixture
+    def task(self, client: InfrahubClientSync) -> _FakeTask:
+        return _FakeTask(client)
+
+    def test_upload_lifecycle(self, task: _FakeTask, tmp_path) -> None:
+        file_path = tmp_path / "lifecycle.txt"
+        file_path.write_bytes(b"v1 content")
+
+        # Create
+        r1 = upload_file_object(task=task, kind="TestingTestFile", file_path=str(file_path))
+        assert r1.failed is False, r1.result
+        assert r1.changed is True
+        assert "created" in r1.result
+        object_id = r1.object_id
+
+        # Idempotent skip (same content, same object)
+        r2 = upload_file_object(
+            task=task,
+            kind="TestingTestFile",
+            file_path=str(file_path),
+            object_id=object_id,
+        )
+        assert r2.failed is False, r2.result
+        assert r2.changed is False
+        assert "up to date" in r2.result
+
+        # Update with changed content
+        file_path.write_bytes(b"v2 content - different")
+        r3 = upload_file_object(
+            task=task,
+            kind="TestingTestFile",
+            file_path=str(file_path),
+            object_id=object_id,
+        )
+        assert r3.failed is False, r3.result
+        assert r3.changed is True
+        assert "updated" in r3.result
+
+    def test_download_returns_content(self, task: _FakeTask, tmp_path) -> None:
+        src = tmp_path / "download_src.txt"
+        content = b"hello download world"
+        src.write_bytes(content)
+
+        up = upload_file_object(task=task, kind="TestingTestFile", file_path=str(src))
+        assert up.failed is False, up.result
+
+        dn = download_file_object(task=task, kind="TestingTestFile", object_id=up.object_id)
+        assert dn.failed is False, dn.result
+        assert dn.file_name == "download_src.txt"
+        assert base64.b64decode(dn.binary) == content
+
+    def test_download_skip_when_local_matches(self, task: _FakeTask, tmp_path) -> None:
+        src = tmp_path / "skip_src.txt"
+        content = b"identical bytes for skip"
+        src.write_bytes(content)
+        up = upload_file_object(task=task, kind="TestingTestFile", file_path=str(src))
+        assert up.failed is False, up.result
+
+        target = tmp_path / "dl" / "skip_src.txt"
+        d1 = download_file_object(
+            task=task,
+            kind="TestingTestFile",
+            object_id=up.object_id,
+            save_to=str(target),
+        )
+        assert d1.failed is False, d1.result
+        assert d1.changed is True
+        assert target.read_bytes() == content
+
+        # Second download — local already matches server checksum → no rewrite
+        d2 = download_file_object(
+            task=task,
+            kind="TestingTestFile",
+            object_id=up.object_id,
+            save_to=str(target),
+        )
+        assert d2.failed is False, d2.result
+        assert d2.changed is False
+
+    def test_data_attr_persists_on_skip(self, task: _FakeTask, client: InfrahubClientSync, tmp_path) -> None:
+        f = tmp_path / "attr.txt"
+        f.write_bytes(b"unchanged content")
+
+        # Create (no label yet)
+        up = upload_file_object(task=task, kind="TestingTestFile", file_path=str(f))
+        assert up.failed is False, up.result
+        object_id = up.object_id
+
+        # Re-upload identical content + a label — file is unchanged, but the label
+        # should be persisted (review #2 behaviour).
+        r = upload_file_object(
+            task=task,
+            kind="TestingTestFile",
+            file_path=str(f),
+            object_id=object_id,
+            data={"label": "after-update"},
+        )
+        assert r.failed is False, r.result
+        assert r.changed is True
+        assert "attributes updated" in r.result
+
+        # Verify the label was actually persisted on the server.
+        obj = client.get(kind="TestingTestFile", id=object_id)
+        assert obj.label.value == "after-update"
+
+    def test_explicit_object_id_not_found_fails(self, task: _FakeTask, tmp_path) -> None:
+        f = tmp_path / "miss.txt"
+        f.write_bytes(b"x")
+        result = upload_file_object(
+            task=task,
+            kind="TestingTestFile",
+            file_path=str(f),
+            object_id="00000000-0000-0000-0000-000000000000",
+        )
+        assert result.failed is True
+        assert "not found" in result.result
+
+    def test_unknown_key_in_data_fails_on_update(self, task: _FakeTask, tmp_path) -> None:
+        f = tmp_path / "unknown_key.txt"
+        f.write_bytes(b"data")
+
+        first = upload_file_object(task=task, kind="TestingTestFile", file_path=str(f))
+        assert first.failed is False, first.result
+
+        result = upload_file_object(
+            task=task,
+            kind="TestingTestFile",
+            file_path=str(f),
+            object_id=first.object_id,
+            data={"totally_bogus_key": "x"},
+        )
+        assert result.failed is True
+        assert "Unknown key 'totally_bogus_key'" in result.result

--- a/tests/unit/test_file_object.py
+++ b/tests/unit/test_file_object.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -10,10 +11,6 @@ from nornir_infrahub.plugins.tasks.file_object import (
     download_file_object,
     upload_file_object,
 )
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
 
 
 def _make_attr(value):
@@ -23,34 +20,32 @@ def _make_attr(value):
     return attr
 
 
-def _make_mock_node(
-    node_id: str = "aaaa-bbbb-cccc-dddd",
+def _make_mock_object(
+    object_id: str = "aaaa-bbbb-cccc-dddd",
     checksum: str = "abc123",
     file_name: str = "contract.pdf",
     file_type: str = "application/pdf",
     file_size: int = 1024,
 ):
     """Create a mock InfrahubNodeSync with CoreFileObject attributes."""
-    node = MagicMock()
-    node.id = node_id
-    node.checksum = _make_attr(checksum)
-    node.file_name = _make_attr(file_name)
-    node.file_type = _make_attr(file_type)
-    node.file_size = _make_attr(file_size)
-    node._schema = MagicMock()
-    node._schema.attribute_names = ["file_name", "file_type", "file_size", "checksum"]
-    return node
+    obj = MagicMock()
+    obj.id = object_id
+    obj.checksum = _make_attr(checksum)
+    obj.file_name = _make_attr(file_name)
+    obj.file_type = _make_attr(file_type)
+    obj.file_size = _make_attr(file_size)
+    obj._schema = MagicMock()
+    obj._schema.attribute_names = ["file_name", "file_type", "file_size", "checksum"]
+    return obj
 
 
 def _make_mock_schema(inherit_from: list[str] | None = None):
-    """Create a mock NodeSchemaAPI."""
     schema = MagicMock()
     schema.inherit_from = inherit_from if inherit_from is not None else ["CoreFileObject"]
     return schema
 
 
 def _make_task():
-    """Create a mock Nornir Task with an InfrahubNode in host data."""
     task = MagicMock()
     task.host = MagicMock()
     task.host.data = {"InfrahubNode": MagicMock()}
@@ -58,19 +53,11 @@ def _make_task():
 
 
 def _get_client_from_task(task):
-    """Extract the mock client from a mock task."""
     return task.host.data["InfrahubNode"]._client
 
 
-# ---------------------------------------------------------------------------
-# US1: Upload tests
-# ---------------------------------------------------------------------------
-
-
 class TestUploadCreateNew:
-    """T006: Upload creates a new node when no existing node is found."""
-
-    def test_upload_creates_new_node(self, tmp_path: Path):
+    def test_upload_creates_new_object(self, tmp_path: Path):
         test_file = tmp_path / "contract.pdf"
         test_file.write_bytes(b"pdf content here")
 
@@ -79,8 +66,8 @@ class TestUploadCreateNew:
         client.schema.get.return_value = _make_mock_schema()
         client.get.side_effect = Exception("not found")
 
-        new_node = _make_mock_node()
-        client.create.return_value = new_node
+        new_obj = _make_mock_object()
+        client.create.return_value = new_obj
 
         result = upload_file_object(task=task, kind="NetworkContract", file_path=str(test_file))
 
@@ -88,13 +75,84 @@ class TestUploadCreateNew:
         assert result.changed is True
         assert "created" in result.result
         client.create.assert_called_once()
-        new_node.upload_from_path.assert_called_once_with(test_file)
-        new_node.save.assert_called_once()
+        new_obj.upload_from_path.assert_called_once_with(test_file)
+        new_obj.save.assert_called_once()
+
+    def test_upload_accepts_path_object(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"pdf content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = Exception("not found")
+
+        new_obj = _make_mock_object()
+        client.create.return_value = new_obj
+
+        result = upload_file_object(task=task, kind="NetworkContract", file_path=test_file)
+
+        assert result.failed is False
+        assert result.changed is True
+        new_obj.upload_from_path.assert_called_once_with(test_file)
+
+
+class TestUploadFromBytes:
+    def test_upload_creates_object_from_bytes(self):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = Exception("not found")
+
+        new_obj = _make_mock_object()
+        client.create.return_value = new_obj
+
+        payload = b"inline bytes content"
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            content=payload,
+            file_name="inline.txt",
+        )
+
+        assert result.failed is False
+        assert result.changed is True
+        new_obj.upload_from_bytes.assert_called_once_with(content=payload, name="inline.txt")
+        new_obj.save.assert_called_once()
+
+    def test_upload_bytes_requires_file_name(self):
+        task = _make_task()
+
+        result = upload_file_object(task=task, kind="NetworkContract", content=b"data")
+
+        assert result.failed is True
+        assert "file_name" in result.result
+
+    def test_upload_rejects_both_file_path_and_content(self, tmp_path: Path):
+        test_file = tmp_path / "f.txt"
+        test_file.write_bytes(b"x")
+
+        task = _make_task()
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            content=b"x",
+            file_name="f.txt",
+        )
+
+        assert result.failed is True
+        assert "Exactly one" in result.result
+
+    def test_upload_rejects_neither_file_path_nor_content(self):
+        task = _make_task()
+        result = upload_file_object(task=task, kind="NetworkContract")
+
+        assert result.failed is True
+        assert "Exactly one" in result.result
 
 
 class TestUploadUpdateChanged:
-    """T007: Upload updates an existing node when the checksum differs."""
-
     def test_upload_updates_when_checksum_differs(self, tmp_path: Path):
         test_file = tmp_path / "contract.pdf"
         test_file.write_bytes(b"updated content")
@@ -103,32 +161,28 @@ class TestUploadUpdateChanged:
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
-        existing_node = _make_mock_node(checksum="old-checksum-does-not-match")
-        client.get.return_value = existing_node
+        existing_obj = _make_mock_object(checksum="old-checksum-does-not-match")
+        client.get.return_value = existing_obj
 
         result = upload_file_object(
             task=task,
             kind="NetworkContract",
             file_path=str(test_file),
-            node_id="aaaa-bbbb-cccc-dddd",
+            object_id="aaaa-bbbb-cccc-dddd",
         )
 
         assert result.failed is False
         assert result.changed is True
         assert "updated" in result.result
-        existing_node.upload_from_path.assert_called_once_with(test_file)
-        existing_node.save.assert_called_once()
+        existing_obj.upload_from_path.assert_called_once_with(test_file)
+        existing_obj.save.assert_called_once()
 
 
 class TestUploadSkipUnchanged:
-    """T008: Upload skips when local checksum matches server checksum."""
-
     def test_upload_skips_when_checksums_match(self, tmp_path: Path):
         test_file = tmp_path / "contract.pdf"
         content = b"unchanged content"
         test_file.write_bytes(content)
-
-        import hashlib
 
         expected_checksum = hashlib.sha1(content, usedforsecurity=False).hexdigest()
 
@@ -136,26 +190,24 @@ class TestUploadSkipUnchanged:
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
-        existing_node = _make_mock_node(checksum=expected_checksum)
-        client.get.return_value = existing_node
+        existing_obj = _make_mock_object(checksum=expected_checksum)
+        client.get.return_value = existing_obj
 
         result = upload_file_object(
             task=task,
             kind="NetworkContract",
             file_path=str(test_file),
-            node_id="aaaa-bbbb-cccc-dddd",
+            object_id="aaaa-bbbb-cccc-dddd",
         )
 
         assert result.failed is False
         assert result.changed is False
         assert "up to date" in result.result
-        existing_node.upload_from_path.assert_not_called()
-        existing_node.save.assert_not_called()
+        existing_obj.upload_from_path.assert_not_called()
+        existing_obj.save.assert_not_called()
 
 
 class TestUploadInvalidKind:
-    """T009: Upload fails when kind does not inherit from CoreFileObject."""
-
     def test_upload_fails_for_non_file_object_kind(self, tmp_path: Path):
         test_file = tmp_path / "data.txt"
         test_file.write_bytes(b"data")
@@ -171,8 +223,6 @@ class TestUploadInvalidKind:
 
 
 class TestUploadMissingFile:
-    """T010: Upload fails when file_path does not exist."""
-
     def test_upload_fails_for_missing_file(self):
         task = _make_task()
 
@@ -180,79 +230,98 @@ class TestUploadMissingFile:
 
         assert result.failed is True
         assert "does not exist" in result.result
-        # Verify no API calls were made
         client = _get_client_from_task(task)
         client.schema.get.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# US2: Download tests
-# ---------------------------------------------------------------------------
+class TestUploadKwargsPassthrough:
+    def test_upload_forwards_kwargs_to_create(self, tmp_path: Path):
+        test_file = tmp_path / "c.pdf"
+        test_file.write_bytes(b"content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = Exception("not found")
+        client.create.return_value = _make_mock_object()
+
+        expected_timeout = 30
+        upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            allow_upsert=True,
+            timeout=expected_timeout,
+        )
+
+        _, kwargs = client.create.call_args
+        assert kwargs.get("allow_upsert") is True
+        assert kwargs.get("timeout") == expected_timeout
 
 
 class TestDownloadTextMime:
-    """T013: Download returns binary + text for text MIME types."""
-
     def test_download_text_file(self):
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
         content = b'{"key": "value"}'
-        node = _make_mock_node(file_type="application/json", file_name="data.json", file_size=len(content))
-        node.download_file.return_value = content
-        client.get.return_value = node
+        obj = _make_mock_object(file_type="application/json", file_name="data.json", file_size=len(content))
+        obj.download_file.return_value = content
+        client.get.return_value = obj
 
-        result = download_file_object(task=task, kind="NetworkConfig", node_id="aaaa-bbbb-cccc-dddd")
+        result = download_file_object(task=task, kind="NetworkConfig", object_id="aaaa-bbbb-cccc-dddd")
 
         assert result.failed is False
+        assert result.changed is False
         assert result.binary == base64.b64encode(content).decode("ascii")
         assert result.text == content.decode("utf-8")
         assert result.file_name == "data.json"
         assert result.file_type == "application/json"
         assert result.file_size == len(content)
-        assert result.node_id == "aaaa-bbbb-cccc-dddd"
+        assert result.object_id == "aaaa-bbbb-cccc-dddd"
 
 
 class TestDownloadBinaryMime:
-    """T014: Download returns binary only (text=None) for binary MIME types."""
-
     def test_download_binary_file(self):
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
         content = b"\x89PNG\r\n\x1a\n"
-        node = _make_mock_node(file_type="image/png", file_name="photo.png", file_size=len(content))
-        node.download_file.return_value = content
-        client.get.return_value = node
+        obj = _make_mock_object(file_type="image/png", file_name="photo.png", file_size=len(content))
+        obj.download_file.return_value = content
+        client.get.return_value = obj
 
-        result = download_file_object(task=task, kind="SitePhoto", node_id="aaaa-bbbb-cccc-dddd")
+        result = download_file_object(task=task, kind="SitePhoto", object_id="aaaa-bbbb-cccc-dddd")
 
         assert result.failed is False
         assert result.binary == base64.b64encode(content).decode("ascii")
         assert result.text is None
 
 
-class TestDownloadSaveToDest:
-    """T015: Download saves file to dest path."""
-
+class TestDownloadSaveTo:
     def test_download_saves_to_directory(self, tmp_path: Path):
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
         content = b"file content"
-        node = _make_mock_node(file_name="report.txt", file_type="text/plain", file_size=len(content))
-        node.download_file.return_value = content
-        client.get.return_value = node
+        obj = _make_mock_object(file_name="report.txt", file_type="text/plain", file_size=len(content))
+        obj.download_file.return_value = content
+        client.get.return_value = obj
 
-        dest_dir = str(tmp_path) + "/"
-        result = download_file_object(task=task, kind="FileReport", node_id="aaaa-bbbb-cccc-dddd", dest=dest_dir)
+        result = download_file_object(
+            task=task,
+            kind="FileReport",
+            object_id="aaaa-bbbb-cccc-dddd",
+            save_to=str(tmp_path) + "/",
+        )
 
         assert result.failed is False
-        assert result.dest == str(tmp_path / "report.txt")
-        assert Path(result.dest).read_bytes() == content
+        assert result.changed is True
+        assert result.save_to == str(tmp_path / "report.txt")
+        assert Path(result.save_to).read_bytes() == content
 
     def test_download_saves_to_explicit_path(self, tmp_path: Path):
         task = _make_task()
@@ -260,62 +329,129 @@ class TestDownloadSaveToDest:
         client.schema.get.return_value = _make_mock_schema()
 
         content = b"file content"
-        node = _make_mock_node(file_name="report.txt", file_type="text/plain", file_size=len(content))
-        node.download_file.return_value = content
-        client.get.return_value = node
+        obj = _make_mock_object(file_name="report.txt", file_type="text/plain", file_size=len(content))
+        obj.download_file.return_value = content
+        client.get.return_value = obj
 
-        dest_file = str(tmp_path / "custom_name.txt")
-        result = download_file_object(task=task, kind="FileReport", node_id="aaaa-bbbb-cccc-dddd", dest=dest_file)
+        explicit = tmp_path / "custom_name.txt"
+        result = download_file_object(
+            task=task,
+            kind="FileReport",
+            object_id="aaaa-bbbb-cccc-dddd",
+            save_to=explicit,
+        )
 
         assert result.failed is False
-        assert result.dest == dest_file
-        assert Path(dest_file).read_bytes() == content
+        assert result.changed is True
+        assert result.save_to == str(explicit)
+        assert explicit.read_bytes() == content
 
+    def test_download_skips_write_when_local_matches(self, tmp_path: Path):
+        content = b"identical content"
+        checksum = hashlib.sha1(content, usedforsecurity=False).hexdigest()
 
-class TestDownloadNodeNotFound:
-    """T016: Download fails when node is not found."""
+        existing_file = tmp_path / "report.txt"
+        existing_file.write_bytes(content)
 
-    def test_download_fails_for_missing_node(self):
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
-        client.get.side_effect = Exception("Node not found")
 
-        result = download_file_object(task=task, kind="NetworkContract", node_id="nonexistent-id")
+        obj = _make_mock_object(
+            file_name="report.txt",
+            file_type="text/plain",
+            file_size=len(content),
+            checksum=checksum,
+        )
+        client.get.return_value = obj
+
+        result = download_file_object(
+            task=task,
+            kind="FileReport",
+            object_id="aaaa-bbbb-cccc-dddd",
+            save_to=existing_file,
+        )
+
+        assert result.failed is False
+        assert result.changed is False
+        assert result.save_to == str(existing_file)
+        obj.download_file.assert_not_called()
+
+    def test_download_overwrites_when_local_differs(self, tmp_path: Path):
+        server_content = b"new server content"
+        server_checksum = hashlib.sha1(server_content, usedforsecurity=False).hexdigest()
+
+        existing_file = tmp_path / "report.txt"
+        existing_file.write_bytes(b"old local content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        obj = _make_mock_object(
+            file_name="report.txt",
+            file_type="text/plain",
+            file_size=len(server_content),
+            checksum=server_checksum,
+        )
+        obj.download_file.return_value = server_content
+        client.get.return_value = obj
+
+        result = download_file_object(
+            task=task,
+            kind="FileReport",
+            object_id="aaaa-bbbb-cccc-dddd",
+            save_to=existing_file,
+        )
+
+        assert result.failed is False
+        assert result.changed is True
+        assert existing_file.read_bytes() == server_content
+
+
+class TestDownloadNotFound:
+    def test_download_fails_for_missing_object(self):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = Exception("Object not found")
+
+        result = download_file_object(task=task, kind="NetworkContract", object_id="nonexistent-id")
 
         assert result.failed is True
-        assert "Node not found" in result.result
+        assert "Object not found" in result.result
 
 
 class TestDownloadMissingIdentifier:
-    """T017: Download fails when neither node_id nor hfid is provided."""
-
     def test_download_fails_without_identifier(self):
         task = _make_task()
 
         result = download_file_object(task=task, kind="NetworkContract")
 
         assert result.failed is True
-        assert "node_id" in result.result or "hfid" in result.result
+        assert "object_id" in result.result or "hfid" in result.result
 
     def test_download_fails_with_both_identifiers(self):
         task = _make_task()
 
-        result = download_file_object(task=task, kind="NetworkContract", node_id="some-id", hfid=["some-hfid"])
+        result = download_file_object(
+            task=task,
+            kind="NetworkContract",
+            object_id="some-id",
+            hfid=["some-hfid"],
+        )
 
         assert result.failed is True
         assert "mutually exclusive" in result.result
 
 
 class TestDownloadInvalidKind:
-    """T018: Download fails when kind does not inherit from CoreFileObject."""
-
     def test_download_fails_for_non_file_object_kind(self):
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema(inherit_from=[])
 
-        result = download_file_object(task=task, kind="BuiltinTag", node_id="some-id")
+        result = download_file_object(task=task, kind="BuiltinTag", object_id="some-id")
 
         assert result.failed is True
         assert "CoreFileObject" in result.result

--- a/tests/unit/test_file_object.py
+++ b/tests/unit/test_file_object.py
@@ -6,6 +6,7 @@ import base64
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from infrahub_sdk.exceptions import NodeNotFoundError
 from nornir_infrahub.plugins.tasks.file_object import (
     download_file_object,
     upload_file_object,
@@ -63,7 +64,7 @@ class TestUploadCreateNew:
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
-        client.get.side_effect = Exception("not found")
+        client.get.side_effect = NodeNotFoundError(identifier={})
 
         new_obj = _make_mock_object()
         client.create.return_value = new_obj
@@ -83,7 +84,7 @@ class TestUploadCreateNew:
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
-        client.get.side_effect = Exception("not found")
+        client.get.side_effect = NodeNotFoundError(identifier={})
 
         new_obj = _make_mock_object()
         client.create.return_value = new_obj
@@ -100,7 +101,7 @@ class TestUploadFromBytes:
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
-        client.get.side_effect = Exception("not found")
+        client.get.side_effect = NodeNotFoundError(identifier={})
 
         new_obj = _make_mock_object()
         client.create.return_value = new_obj
@@ -225,6 +226,59 @@ class TestUploadSkipUnchanged:
         existing_obj.upload_if_changed.assert_called_once_with(test_file, "contract.pdf")
 
 
+class TestUploadAttrsOnSkip:
+    def test_upload_persists_data_attrs_when_file_unchanged(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"unchanged content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_obj = _make_mock_object(file_type="application/pdf")
+        existing_obj.upload_if_changed.return_value = MagicMock(was_uploaded=False)
+        client.get.return_value = existing_obj
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            object_id="aaaa-bbbb-cccc-dddd",
+            data={"file_type": "text/markdown"},
+        )
+
+        assert result.failed is False
+        assert result.changed is True
+        assert "attributes updated" in result.result
+        existing_obj.save.assert_called_once()
+        assert existing_obj.file_type == "text/markdown"
+
+    def test_upload_skip_no_save_when_data_matches(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"unchanged content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_obj = _make_mock_object(file_type="application/pdf")
+        existing_obj.upload_if_changed.return_value = MagicMock(was_uploaded=False)
+        client.get.return_value = existing_obj
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            object_id="aaaa-bbbb-cccc-dddd",
+            data={"file_type": "application/pdf"},
+        )
+
+        assert result.failed is False
+        assert result.changed is False
+        assert "up to date" in result.result
+        existing_obj.save.assert_not_called()
+
+
 class TestUploadInvalidKind:
     def test_upload_fails_for_non_file_object_kind(self, tmp_path: Path):
         test_file = tmp_path / "data.txt"
@@ -260,7 +314,7 @@ class TestUploadKwargsPassthrough:
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
-        client.get.side_effect = Exception("not found")
+        client.get.side_effect = NodeNotFoundError(identifier={})
         client.create.return_value = _make_mock_object()
 
         expected_timeout = 30

--- a/tests/unit/test_file_object.py
+++ b/tests/unit/test_file_object.py
@@ -1,0 +1,321 @@
+"""Unit tests for CoreFileObject upload and download tasks."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nornir_infrahub.plugins.tasks.file_object import (
+    download_file_object,
+    upload_file_object,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_attr(value):
+    """Create a mock attribute with a .value property."""
+    attr = MagicMock()
+    attr.value = value
+    return attr
+
+
+def _make_mock_node(
+    node_id: str = "aaaa-bbbb-cccc-dddd",
+    checksum: str = "abc123",
+    file_name: str = "contract.pdf",
+    file_type: str = "application/pdf",
+    file_size: int = 1024,
+):
+    """Create a mock InfrahubNodeSync with CoreFileObject attributes."""
+    node = MagicMock()
+    node.id = node_id
+    node.checksum = _make_attr(checksum)
+    node.file_name = _make_attr(file_name)
+    node.file_type = _make_attr(file_type)
+    node.file_size = _make_attr(file_size)
+    node._schema = MagicMock()
+    node._schema.attribute_names = ["file_name", "file_type", "file_size", "checksum"]
+    return node
+
+
+def _make_mock_schema(inherit_from: list[str] | None = None):
+    """Create a mock NodeSchemaAPI."""
+    schema = MagicMock()
+    schema.inherit_from = inherit_from if inherit_from is not None else ["CoreFileObject"]
+    return schema
+
+
+def _make_task():
+    """Create a mock Nornir Task with an InfrahubNode in host data."""
+    task = MagicMock()
+    task.host = MagicMock()
+    task.host.data = {"InfrahubNode": MagicMock()}
+    return task
+
+
+def _get_client_from_task(task):
+    """Extract the mock client from a mock task."""
+    return task.host.data["InfrahubNode"]._client
+
+
+# ---------------------------------------------------------------------------
+# US1: Upload tests
+# ---------------------------------------------------------------------------
+
+
+class TestUploadCreateNew:
+    """T006: Upload creates a new node when no existing node is found."""
+
+    def test_upload_creates_new_node(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"pdf content here")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = Exception("not found")
+
+        new_node = _make_mock_node()
+        client.create.return_value = new_node
+
+        result = upload_file_object(task=task, kind="NetworkContract", file_path=str(test_file))
+
+        assert result.failed is False
+        assert result.changed is True
+        assert "created" in result.result
+        client.create.assert_called_once()
+        new_node.upload_from_path.assert_called_once_with(test_file)
+        new_node.save.assert_called_once()
+
+
+class TestUploadUpdateChanged:
+    """T007: Upload updates an existing node when the checksum differs."""
+
+    def test_upload_updates_when_checksum_differs(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"updated content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_node = _make_mock_node(checksum="old-checksum-does-not-match")
+        client.get.return_value = existing_node
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            node_id="aaaa-bbbb-cccc-dddd",
+        )
+
+        assert result.failed is False
+        assert result.changed is True
+        assert "updated" in result.result
+        existing_node.upload_from_path.assert_called_once_with(test_file)
+        existing_node.save.assert_called_once()
+
+
+class TestUploadSkipUnchanged:
+    """T008: Upload skips when local checksum matches server checksum."""
+
+    def test_upload_skips_when_checksums_match(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        content = b"unchanged content"
+        test_file.write_bytes(content)
+
+        import hashlib
+
+        expected_checksum = hashlib.sha1(content, usedforsecurity=False).hexdigest()
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_node = _make_mock_node(checksum=expected_checksum)
+        client.get.return_value = existing_node
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            node_id="aaaa-bbbb-cccc-dddd",
+        )
+
+        assert result.failed is False
+        assert result.changed is False
+        assert "up to date" in result.result
+        existing_node.upload_from_path.assert_not_called()
+        existing_node.save.assert_not_called()
+
+
+class TestUploadInvalidKind:
+    """T009: Upload fails when kind does not inherit from CoreFileObject."""
+
+    def test_upload_fails_for_non_file_object_kind(self, tmp_path: Path):
+        test_file = tmp_path / "data.txt"
+        test_file.write_bytes(b"data")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema(inherit_from=[])
+
+        result = upload_file_object(task=task, kind="BuiltinTag", file_path=str(test_file))
+
+        assert result.failed is True
+        assert "CoreFileObject" in result.result
+
+
+class TestUploadMissingFile:
+    """T010: Upload fails when file_path does not exist."""
+
+    def test_upload_fails_for_missing_file(self):
+        task = _make_task()
+
+        result = upload_file_object(task=task, kind="NetworkContract", file_path="/nonexistent/file.pdf")
+
+        assert result.failed is True
+        assert "does not exist" in result.result
+        # Verify no API calls were made
+        client = _get_client_from_task(task)
+        client.schema.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# US2: Download tests
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadTextMime:
+    """T013: Download returns binary + text for text MIME types."""
+
+    def test_download_text_file(self):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        content = b'{"key": "value"}'
+        node = _make_mock_node(file_type="application/json", file_name="data.json", file_size=len(content))
+        node.download_file.return_value = content
+        client.get.return_value = node
+
+        result = download_file_object(task=task, kind="NetworkConfig", node_id="aaaa-bbbb-cccc-dddd")
+
+        assert result.failed is False
+        assert result.binary == base64.b64encode(content).decode("ascii")
+        assert result.text == content.decode("utf-8")
+        assert result.file_name == "data.json"
+        assert result.file_type == "application/json"
+        assert result.file_size == len(content)
+        assert result.node_id == "aaaa-bbbb-cccc-dddd"
+
+
+class TestDownloadBinaryMime:
+    """T014: Download returns binary only (text=None) for binary MIME types."""
+
+    def test_download_binary_file(self):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        content = b"\x89PNG\r\n\x1a\n"
+        node = _make_mock_node(file_type="image/png", file_name="photo.png", file_size=len(content))
+        node.download_file.return_value = content
+        client.get.return_value = node
+
+        result = download_file_object(task=task, kind="SitePhoto", node_id="aaaa-bbbb-cccc-dddd")
+
+        assert result.failed is False
+        assert result.binary == base64.b64encode(content).decode("ascii")
+        assert result.text is None
+
+
+class TestDownloadSaveToDest:
+    """T015: Download saves file to dest path."""
+
+    def test_download_saves_to_directory(self, tmp_path: Path):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        content = b"file content"
+        node = _make_mock_node(file_name="report.txt", file_type="text/plain", file_size=len(content))
+        node.download_file.return_value = content
+        client.get.return_value = node
+
+        dest_dir = str(tmp_path) + "/"
+        result = download_file_object(task=task, kind="FileReport", node_id="aaaa-bbbb-cccc-dddd", dest=dest_dir)
+
+        assert result.failed is False
+        assert result.dest == str(tmp_path / "report.txt")
+        assert Path(result.dest).read_bytes() == content
+
+    def test_download_saves_to_explicit_path(self, tmp_path: Path):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        content = b"file content"
+        node = _make_mock_node(file_name="report.txt", file_type="text/plain", file_size=len(content))
+        node.download_file.return_value = content
+        client.get.return_value = node
+
+        dest_file = str(tmp_path / "custom_name.txt")
+        result = download_file_object(task=task, kind="FileReport", node_id="aaaa-bbbb-cccc-dddd", dest=dest_file)
+
+        assert result.failed is False
+        assert result.dest == dest_file
+        assert Path(dest_file).read_bytes() == content
+
+
+class TestDownloadNodeNotFound:
+    """T016: Download fails when node is not found."""
+
+    def test_download_fails_for_missing_node(self):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = Exception("Node not found")
+
+        result = download_file_object(task=task, kind="NetworkContract", node_id="nonexistent-id")
+
+        assert result.failed is True
+        assert "Node not found" in result.result
+
+
+class TestDownloadMissingIdentifier:
+    """T017: Download fails when neither node_id nor hfid is provided."""
+
+    def test_download_fails_without_identifier(self):
+        task = _make_task()
+
+        result = download_file_object(task=task, kind="NetworkContract")
+
+        assert result.failed is True
+        assert "node_id" in result.result or "hfid" in result.result
+
+    def test_download_fails_with_both_identifiers(self):
+        task = _make_task()
+
+        result = download_file_object(task=task, kind="NetworkContract", node_id="some-id", hfid=["some-hfid"])
+
+        assert result.failed is True
+        assert "mutually exclusive" in result.result
+
+
+class TestDownloadInvalidKind:
+    """T018: Download fails when kind does not inherit from CoreFileObject."""
+
+    def test_download_fails_for_non_file_object_kind(self):
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema(inherit_from=[])
+
+        result = download_file_object(task=task, kind="BuiltinTag", node_id="some-id")
+
+        assert result.failed is True
+        assert "CoreFileObject" in result.result

--- a/tests/unit/test_file_object.py
+++ b/tests/unit/test_file_object.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -367,7 +366,6 @@ class TestDownloadSaveTo:
 
     def test_download_skips_write_when_local_matches(self, tmp_path: Path):
         content = b"identical content"
-        checksum = hashlib.sha1(content, usedforsecurity=False).hexdigest()
 
         existing_file = tmp_path / "report.txt"
         existing_file.write_bytes(content)
@@ -376,12 +374,8 @@ class TestDownloadSaveTo:
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
-        obj = _make_mock_object(
-            file_name="report.txt",
-            file_type="text/plain",
-            file_size=len(content),
-            checksum=checksum,
-        )
+        obj = _make_mock_object(file_name="report.txt", file_type="text/plain", file_size=len(content))
+        obj.matches_local_checksum.return_value = True
         client.get.return_value = obj
 
         result = download_file_object(
@@ -394,11 +388,11 @@ class TestDownloadSaveTo:
         assert result.failed is False
         assert result.changed is False
         assert result.save_to == str(existing_file)
+        obj.matches_local_checksum.assert_called_once_with(existing_file)
         obj.download_file.assert_not_called()
 
     def test_download_overwrites_when_local_differs(self, tmp_path: Path):
         server_content = b"new server content"
-        server_checksum = hashlib.sha1(server_content, usedforsecurity=False).hexdigest()
 
         existing_file = tmp_path / "report.txt"
         existing_file.write_bytes(b"old local content")
@@ -407,12 +401,8 @@ class TestDownloadSaveTo:
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
-        obj = _make_mock_object(
-            file_name="report.txt",
-            file_type="text/plain",
-            file_size=len(server_content),
-            checksum=server_checksum,
-        )
+        obj = _make_mock_object(file_name="report.txt", file_type="text/plain", file_size=len(server_content))
+        obj.matches_local_checksum.return_value = False
         obj.download_file.return_value = server_content
         client.get.return_value = obj
 
@@ -426,6 +416,7 @@ class TestDownloadSaveTo:
         assert result.failed is False
         assert result.changed is True
         assert existing_file.read_bytes() == server_content
+        obj.matches_local_checksum.assert_called_once_with(existing_file)
 
 
 class TestDownloadNotFound:

--- a/tests/unit/test_file_object.py
+++ b/tests/unit/test_file_object.py
@@ -36,6 +36,7 @@ def _make_mock_object(
     obj.file_size = _make_attr(file_size)
     obj._schema = MagicMock()
     obj._schema.attribute_names = ["file_name", "file_type", "file_size", "checksum"]
+    obj._schema.relationship_names = []
     return obj
 
 
@@ -277,6 +278,97 @@ class TestUploadAttrsOnSkip:
         assert result.changed is False
         assert "up to date" in result.result
         existing_obj.save.assert_not_called()
+
+
+class TestUploadDataValidation:
+    def test_upload_fails_on_relationship_key_in_data(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_obj = _make_mock_object()
+        existing_obj._schema.relationship_names = ["artifact"]
+        client.get.return_value = existing_obj
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            object_id="aaaa-bbbb-cccc-dddd",
+            data={"artifact": "rel-id-123"},
+        )
+
+        assert result.failed is True
+        assert "relationship 'artifact'" in result.result
+        existing_obj.upload_if_changed.assert_not_called()
+
+    def test_upload_fails_on_unknown_key_in_data(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_obj = _make_mock_object()
+        client.get.return_value = existing_obj
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            object_id="aaaa-bbbb-cccc-dddd",
+            data={"bogus_key": "x"},
+        )
+
+        assert result.failed is True
+        assert "Unknown key 'bogus_key'" in result.result
+        existing_obj.upload_if_changed.assert_not_called()
+
+
+class TestUploadLookupErrors:
+    def test_upload_fails_when_explicit_object_id_not_found(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = NodeNotFoundError(identifier={})
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            object_id="nonexistent-uuid",
+        )
+
+        assert result.failed is True
+        assert "not found" in result.result
+        client.create.assert_not_called()
+
+    def test_upload_fails_on_ambiguous_filename_lookup(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+        client.get.side_effect = IndexError("More than 1 node returned")
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+        )
+
+        assert result.failed is True
+        assert "Multiple" in result.result
+        assert "contract.pdf" in result.result
+        client.create.assert_not_called()
 
 
 class TestUploadInvalidKind:

--- a/tests/unit/test_file_object.py
+++ b/tests/unit/test_file_object.py
@@ -75,8 +75,7 @@ class TestUploadCreateNew:
         assert result.changed is True
         assert "created" in result.result
         client.create.assert_called_once()
-        new_obj.upload_from_path.assert_called_once_with(test_file)
-        new_obj.save.assert_called_once()
+        new_obj.upload_if_changed.assert_called_once_with(test_file, "contract.pdf")
 
     def test_upload_accepts_path_object(self, tmp_path: Path):
         test_file = tmp_path / "contract.pdf"
@@ -94,7 +93,7 @@ class TestUploadCreateNew:
 
         assert result.failed is False
         assert result.changed is True
-        new_obj.upload_from_path.assert_called_once_with(test_file)
+        new_obj.upload_if_changed.assert_called_once_with(test_file, "contract.pdf")
 
 
 class TestUploadFromBytes:
@@ -117,8 +116,7 @@ class TestUploadFromBytes:
 
         assert result.failed is False
         assert result.changed is True
-        new_obj.upload_from_bytes.assert_called_once_with(content=payload, name="inline.txt")
-        new_obj.save.assert_called_once()
+        new_obj.upload_if_changed.assert_called_once_with(payload, "inline.txt")
 
     def test_upload_bytes_requires_file_name(self):
         task = _make_task()
@@ -161,7 +159,8 @@ class TestUploadUpdateChanged:
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
-        existing_obj = _make_mock_object(checksum="old-checksum-does-not-match")
+        existing_obj = _make_mock_object()
+        existing_obj.upload_if_changed.return_value = MagicMock(was_uploaded=True)
         client.get.return_value = existing_obj
 
         result = upload_file_object(
@@ -174,23 +173,44 @@ class TestUploadUpdateChanged:
         assert result.failed is False
         assert result.changed is True
         assert "updated" in result.result
-        existing_obj.upload_from_path.assert_called_once_with(test_file)
-        existing_obj.save.assert_called_once()
+        existing_obj.upload_if_changed.assert_called_once_with(test_file, "contract.pdf")
 
-
-class TestUploadSkipUnchanged:
-    def test_upload_skips_when_checksums_match(self, tmp_path: Path):
+    def test_upload_applies_data_attrs_on_update(self, tmp_path: Path):
         test_file = tmp_path / "contract.pdf"
-        content = b"unchanged content"
-        test_file.write_bytes(content)
-
-        expected_checksum = hashlib.sha1(content, usedforsecurity=False).hexdigest()
+        test_file.write_bytes(b"updated content")
 
         task = _make_task()
         client = _get_client_from_task(task)
         client.schema.get.return_value = _make_mock_schema()
 
-        existing_obj = _make_mock_object(checksum=expected_checksum)
+        existing_obj = _make_mock_object()
+        existing_obj.upload_if_changed.return_value = MagicMock(was_uploaded=True)
+        client.get.return_value = existing_obj
+
+        result = upload_file_object(
+            task=task,
+            kind="NetworkContract",
+            file_path=str(test_file),
+            object_id="aaaa-bbbb-cccc-dddd",
+            data={"file_type": "text/markdown"},
+        )
+
+        assert result.failed is False
+        assert result.changed is True
+        assert existing_obj.file_type == "text/markdown"
+
+
+class TestUploadSkipUnchanged:
+    def test_upload_skips_when_checksums_match(self, tmp_path: Path):
+        test_file = tmp_path / "contract.pdf"
+        test_file.write_bytes(b"unchanged content")
+
+        task = _make_task()
+        client = _get_client_from_task(task)
+        client.schema.get.return_value = _make_mock_schema()
+
+        existing_obj = _make_mock_object()
+        existing_obj.upload_if_changed.return_value = MagicMock(was_uploaded=False)
         client.get.return_value = existing_obj
 
         result = upload_file_object(
@@ -203,8 +223,7 @@ class TestUploadSkipUnchanged:
         assert result.failed is False
         assert result.changed is False
         assert "up to date" in result.result
-        existing_obj.upload_from_path.assert_not_called()
-        existing_obj.save.assert_not_called()
+        existing_obj.upload_if_changed.assert_called_once_with(test_file, "contract.pdf")
 
 
 class TestUploadInvalidKind:

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.17.0"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dulwich" },
@@ -467,9 +467,9 @@ dependencies = [
     { name = "ujson" },
     { name = "whenever" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/60/47f22fea92421085c449be78ad7219c66e2417978cd73a05aeb5c5159562/infrahub_sdk-1.17.0.tar.gz", hash = "sha256:2eca77193a855efe9819374e3d5c53eabcfcf13e3af90cc294d327b3844c41d0", size = 749554, upload-time = "2025-12-11T08:18:04.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/43/86aa7711e89e4abea8216b462c43d46d298cb076fc53db1b05a91eabdcc7/infrahub_sdk-1.19.0.tar.gz", hash = "sha256:a397d1ea5c3747cf661cdab99cc4339886458afc246e14e13de72d5bc0dae3bd", size = 874068, upload-time = "2026-03-16T15:27:29.431Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/66/b95ea7f7e228d62e111ae1b79659a84bc1cfaf61781d3edd6b2194ca8cfc/infrahub_sdk-1.17.0-py3-none-any.whl", hash = "sha256:e5f0d016e7a2276cb87c9268596bfa0e23aa17c3397270c218be30812d4150a9", size = 194423, upload-time = "2025-12-11T08:18:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/17/4d/4302c2cde325fdb486736da3b71b309041c69b23cd9b39707aa4b5bedf02/infrahub_sdk-1.19.0-py3-none-any.whl", hash = "sha256:40f9e31b83a8ed472f5b49f77f7158620f33ee05c74cb0ca29e9397918be7db4", size = 212058, upload-time = "2026-03-16T15:27:27.948Z" },
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "infrahub-sdk", specifier = ">=1.17.0,<2" },
+    { name = "infrahub-sdk", specifier = ">=1.19.0,<2" },
     { name = "nornir", specifier = ">=3.5.0,<4" },
     { name = "nornir-utils", specifier = ">=0.2.0,<0.3" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.19.0"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dulwich" },
@@ -467,9 +467,9 @@ dependencies = [
     { name = "ujson" },
     { name = "whenever" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/43/86aa7711e89e4abea8216b462c43d46d298cb076fc53db1b05a91eabdcc7/infrahub_sdk-1.19.0.tar.gz", hash = "sha256:a397d1ea5c3747cf661cdab99cc4339886458afc246e14e13de72d5bc0dae3bd", size = 874068, upload-time = "2026-03-16T15:27:29.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/c9/6be3dce3184422f1baa222035998bc9552ed30cdf9a73694c7387db2d6f3/infrahub_sdk-1.20.1.tar.gz", hash = "sha256:5b7134814d8a700bcae9069aeabc4cf0b18d4f7234dd5867c665b26620393d83", size = 1025138, upload-time = "2026-05-20T13:45:30.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/4d/4302c2cde325fdb486736da3b71b309041c69b23cd9b39707aa4b5bedf02/infrahub_sdk-1.19.0-py3-none-any.whl", hash = "sha256:40f9e31b83a8ed472f5b49f77f7158620f33ee05c74cb0ca29e9397918be7db4", size = 212058, upload-time = "2026-03-16T15:27:27.948Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4f/0533d93f6805b82bb44e19e76855f6a8e5b4c8810c95d770dfc5abaf10a0/infrahub_sdk-1.20.1-py3-none-any.whl", hash = "sha256:82439aff95408d31dcd00661833804907d952dd7ae7b2cae3be8ed35c7bd85aa", size = 246235, upload-time = "2026-05-20T13:45:28.412Z" },
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "infrahub-sdk", specifier = ">=1.19.0,<2" },
+    { name = "infrahub-sdk", specifier = ">=1.20.1,<2" },
     { name = "nornir", specifier = ">=3.5.0,<4" },
     { name = "nornir-utils", specifier = ">=0.2.0,<0.3" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },


### PR DESCRIPTION
# Initial support for file upload

## Summary

Add CoreFileObject support to nornir-infrahub with two new Nornir task functions:

- **`upload_file_object`** — Upload a local file (or raw bytes) to an Infrahub node that inherits from CoreFileObject. Creates the node if it doesn't exist, updates it if the file changed, and skips the upload entirely when the SHA-1 checksum matches (idempotent). On update, `data` attribute changes are persisted even when the file content is unchanged.
- **`download_file_object`** — Download file content from a CoreFileObject node. Returns base64-encoded binary plus a UTF-8 `text` view for known text MIME types. Optionally writes to a local `save_to` path; skips the write when the local file already matches the server checksum.

Mirrors the CoreFileObject support added to the Ansible collection in [opsmill/infrahub-ansible#317](https://github.com/opsmill/infrahub-ansible/pull/317).

## Changes

- **`nornir_infrahub/plugins/tasks/file_object.py`** — new module with the two task functions, helpers (`_validate_file_object_kind`, `_lookup_existing_object`, `_resolve_upload_source`), and the `TEXT_MIME_TYPES` constant. Idempotency and checksum comparison are delegated to the SDK via `node.upload_if_changed(source, name)` and `node.matches_local_checksum(source)`.
- **`nornir_infrahub/plugins/tasks/__init__.py`** — export the two new functions.
- **`nornir_infrahub/utils.py`** — small `get_client(task)` helper shared between the file_object tasks (ready for `artifact.py` to adopt as a follow-up).
- **`tests/unit/test_file_object.py`** — 28 unit tests covering create, update, idempotent skip, attribute-only updates on the skip path, rejection of relationship and unknown keys in `data` on update, invalid kind, missing file, explicit `object_id` miss, ambiguous filename lookup, text/binary MIME download, `save_to` dir-vs-file handling, local-match skip, and overwrite-on-mismatch.
- **`pyproject.toml`** — bump `infrahub-sdk` to `>=1.20.1,<2` (first release shipping `upload_if_changed` / `matches_local_checksum` / `UploadResult` from [opsmill/infrahub-sdk-python#963](https://github.com/opsmill/infrahub-sdk-python/pull/963)); scope `PLR0911`/`PLR0912`/`PLR0913` ignores to the tasks directory; keep the three ty rule disables that cover broad SDK-dynamic-type patterns and drop the two that inline `# type: ignore` comments already cover.
- **`docs/`** — auto-generated plugin reference for the two new tasks plus generator fixes the rebase surfaced (pipe-escaping in type names, multi-line description flattening, corrected relative path in `_plugin_index.mdx`, `MD012`/`MD060` disables folded into the canonical `.markdownlint.yml` and the redundant `.markdownlint.json` removed).

## Usage

```python
from nornir_infrahub.plugins.tasks import upload_file_object, download_file_object

# Upload a file (forwards **kwargs to client.create — e.g. allow_upsert, timeout)
result = nr.run(
    task=upload_file_object,
    kind="AvdHostvarFile",
    file_path="/path/to/hostvars.json",
)

# Download a file (save_to writes to disk; binary/text always returned)
result = nr.run(
    task=download_file_object,
    kind="AvdHostvarFile",
    object_id="abcd-1234-efgh-5678",
    save_to="/tmp/downloads/",
)
```

**Behavior notes:**
- `**kwargs` are forwarded to `client.create` and only apply on the create path; they are not used when updating an existing object.
- On update, the `data` dict only sets attributes; passing a relationship key or an unknown key fails the task instead of being silently dropped (use the SDK directly to change relationships on existing nodes).
- A typo'd explicit `object_id` fails the task rather than silently creating a new node; upsert-on-miss is still in effect for `hfid` and the filename fallback.

## Test plan

- [x] Unit tests pass (45/45 — 28 new file_object + 17 existing inventory)
- [x] `ruff check` / `ruff format --check` pass
- [x] `pylint` 10.00/10
- [x] `ty check` passes
- [x] `markdown-lint` / `vale` / docs build pass on CI across Python 3.10–3.13
- [x] Integration tested against a live Infrahub via #79's testcontainers harness. `tests/integration/test_file_object.py` adds a `Testing.TestFile` schema inheriting from `CoreFileObject` and covers upload lifecycle (create → idempotent skip → update), download round-trip, download-skip on local match, metadata-on-skip persistence, explicit-`object_id` not-found failure, and unknown-`data`-key rejection. 6/6 pass locally against testcontainers in ~70s; excluded from CI by #79's `-m 'not integration'` addopts (Docker-only). Run with `pytest tests/integration/test_file_object.py -m integration`.
