### PR TITLE
fix: hydrate related nodes via include= on host fetch

### DIFF
--- a/docs/docs/references/plugins/infrahub_inventory.mdx
+++ b/docs/docs/references/plugins/infrahub_inventory.mdx
@@ -45,7 +45,6 @@ def main():
                 "token": "06438eb2-8019-4776-878c-0941b1f1d1ec",  # Infrahub API token
                 "host_node": {
                     "kind": "InfraDevice",
-                    "include": ["primary_address", "platform", "site"],  # fetch relationship data
                 },
                 "schema_mappings": [
                     {"name": "hostname", "mapping": "primary_address.address"},

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -1,15 +1,13 @@
 """Inventory plugin"""
 
 import ipaddress
-import itertools
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import ruamel.yaml
 from infrahub_sdk import Config, InfrahubClientSync
 from infrahub_sdk.node import InfrahubNodeSync
-from infrahub_sdk.schema import NodeSchemaAPI
 from nornir.core.inventory import (
     ConnectionOptions,
     Defaults,
@@ -25,6 +23,7 @@ from pydantic import BaseModel, Field, model_validator
 from pydantic.dataclasses import dataclass
 from slugify import slugify
 
+MAX_RELATIONSHIP_HOPS: int = 2
 logger = logging.getLogger(__name__)
 
 
@@ -117,15 +116,6 @@ class HostNode(BaseModel):
         return data
 
 
-def get_related_nodes(node_schema: NodeSchemaAPI, attrs: Set[str]) -> Set[str]:
-    nodes = {"CoreStandardGroup"}
-    relationship_schemas = {schema.name: schema.peer for schema in node_schema.relationships}
-    for attr in attrs:
-        if attr in relationship_schemas:
-            nodes.add(relationship_schemas[attr])
-    return nodes
-
-
 class InfrahubInventory:
     """
     Nornir inventory plugin for integrating with `Opsmill - Infrahub`
@@ -214,14 +204,31 @@ class InfrahubInventory:
         self.group_mappings = group_mappings
 
         host_node_schema = self.client.schema.get(kind=self.host_node.kind)
+        host_rel_names = set(host_node_schema.relationship_names)
 
-        attrs = set(
-            itertools.chain(
-                [schema_mapping.mapping.split(".")[0] for schema_mapping in self.schema_mappings],
-                [group_mapping.split(".")[0] for group_mapping in self.group_mappings],
-            )
-        )
-        self.extra_nodes = get_related_nodes(host_node_schema, attrs)
+        mapping_relations: set[str] = set()
+        for source, mapping in self._iter_mappings():
+            parts = mapping.split(".")
+            if len(parts) > MAX_RELATIONSHIP_HOPS:
+                raise ValueError(
+                    f"{source} '{mapping}' spans more than one relation hop; "
+                    "only single-hop mappings (e.g. 'primary_address.address') are supported"
+                )
+            if len(parts) == MAX_RELATIONSHIP_HOPS:
+                if parts[0] not in host_rel_names:
+                    raise ValueError(
+                        f"{source} '{mapping}' references '{parts[0]}', "
+                        f"which is not a relationship on {self.host_node.kind}"
+                    )
+                mapping_relations.add(parts[0])
+
+        self.host_node.include = sorted(set(self.host_node.include) | mapping_relations)
+
+    def _iter_mappings(self):
+        for sm in self.schema_mappings:
+            yield "schema_mapping", sm.mapping
+        for gm in self.group_mappings:
+            yield "group_mapping", gm
 
     def load(self) -> Inventory:  # noqa: PLR0912
         yml = ruamel.yaml.YAML(typ="safe")
@@ -250,9 +257,6 @@ class InfrahubInventory:
             g.groups = ParentGroups([groups[g.name] for g in g.groups])
 
         host: Dict[str, Any] = {}
-
-        for extra_node in self.extra_nodes:
-            self.get_resources(kind=extra_node)
 
         host_nodes = self.get_resources(**dict(self.host_node))
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -103,12 +103,8 @@ async def ipaddress_data():
 
 @pytest.fixture
 @patch("nornir_infrahub.plugins.inventory.infrahub.InfrahubClientSync")
-@patch("nornir_infrahub.plugins.inventory.infrahub.get_related_nodes")
-async def mock_infrahub_inventory(mock_get_related_nodes, mock_infrahub_client) -> InfrahubInventory:
+async def mock_infrahub_inventory(mock_infrahub_client) -> InfrahubInventory:
     mock_infrahub_client.schema.get.return_value = device_schema
-    mock_get_related_nodes.return_value = {
-        "CoreStandardGroup",
-    }
 
     inventory = InfrahubInventory(
         host_node={"kind": "InfraDevice", "include": ["hostname", "platform"]},  # Adjust the parameters as needed

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -12,7 +12,6 @@ from nornir_infrahub.plugins.inventory.infrahub import (  # _get_inventory_eleme
     SchemaMappingNode,
     _get_connection_options,
     _get_defaults,
-    get_related_nodes,
     ip_interface_to_ip_string,
     resolve_node_mapping,
 )
@@ -273,28 +272,6 @@ def test_validate_include_property():
         HostNode(kind="host", include=invalid_include_items)
 
 
-# get_related_nodes
-
-
-def test_get_related_nodes():
-    schema = {
-        "name": "Person",
-        "namespace": "Test",
-        "default_filter": "name__value",
-        "attributes": [
-            {"name": "name", "kind": "Text", "unique": True},
-        ],
-        "relationships": [
-            {"name": "vehicules", "peer": "TestVehicule", "cardinality": "many", "identifier": "person__vehicule"}
-        ],
-    }
-    node_schema = NodeSchemaAPI(**schema)
-    attrs = {"vehicules", "address"}  # "Address" is not in the relationships
-    result = get_related_nodes(node_schema, attrs)
-    expected_result = {"CoreStandardGroup", "TestVehicule"}
-    assert result == expected_result
-
-
 # InfrahubInventory
 
 
@@ -319,6 +296,7 @@ def test_infrahub_inventory_client_config_branch_integration(branch, expected, d
         mock_client = Mock()
         mock_schema = Mock()
         mock_schema.relationships = []
+        mock_schema.relationship_names = []
         mock_client.schema.get.return_value = mock_schema
 
         # Capture the config passed to the constructor
@@ -371,6 +349,7 @@ def test_infrahub_inventory_branch_used_in_get_resources():
         mock_client = Mock()
         mock_schema = Mock()
         mock_schema.relationships = []  # Empty list to avoid iteration error
+        mock_schema.relationship_names = []
         mock_client.schema.get.return_value = mock_schema
         mock_client.filters.return_value = []
         mock_client_class.return_value = mock_client
@@ -413,3 +392,62 @@ def test_infrahub_inventory_branch_used_in_get_resources():
 # XXX todo
 # def test_infrahub_inventory_get_resources():
 #     pass
+
+
+def _patched_inventory(relationship_names, **kwargs):
+    from unittest.mock import Mock, patch
+
+    with patch("nornir_infrahub.plugins.inventory.infrahub.InfrahubClientSync") as mock_client_class:
+        mock_client = Mock()
+        mock_schema = Mock()
+        mock_schema.relationships = []
+        mock_schema.relationship_names = list(relationship_names)
+        mock_client.schema.get.return_value = mock_schema
+        mock_client_class.return_value = mock_client
+        return InfrahubInventory(**kwargs)
+
+
+def test_mapping_relations_merged_into_include():
+    inventory = _patched_inventory(
+        relationship_names=["primary_address", "site", "platform"],
+        host_node={"kind": "InfraDevice", "include": ["interfaces"]},
+        schema_mappings=[
+            {"name": "hostname", "mapping": "primary_address.address"},
+            {"name": "platform", "mapping": "platform.nornir_platform"},
+        ],
+        group_mappings=["site.name"],
+    )
+    assert set(inventory.host_node.include) == {
+        "member_of_groups",
+        "interfaces",
+        "primary_address",
+        "platform",
+        "site",
+    }
+
+
+def test_single_segment_mapping_does_not_add_include():
+    inventory = _patched_inventory(
+        relationship_names=[],
+        host_node={"kind": "InfraDevice"},
+        schema_mappings=[{"name": "hostname", "mapping": "name"}],
+    )
+    assert set(inventory.host_node.include) == {"member_of_groups"}
+
+
+def test_multi_hop_mapping_rejected():
+    with pytest.raises(ValueError, match="more than one relation hop"):
+        _patched_inventory(
+            relationship_names=["primary_address"],
+            host_node={"kind": "InfraDevice"},
+            schema_mappings=[{"name": "prefix", "mapping": "primary_address.ip_prefix.prefix"}],
+        )
+
+
+def test_mapping_references_unknown_relationship():
+    with pytest.raises(ValueError, match="not a relationship"):
+        _patched_inventory(
+            relationship_names=["site"],
+            host_node={"kind": "InfraDevice"},
+            schema_mappings=[{"name": "hostname", "mapping": "primary_address.address"}],
+        )


### PR DESCRIPTION
## Summary
- Replace the pre-fetch-all-related-kinds strategy with targeted
`include=` on the host-node fetch, derived from schema/group mappings.
- Delete `get_related_nodes`, `extra_nodes`, and the separate pre-fetch loop.
- Reject multi-hop mappings and mappings that reference a non-existent
relationship, with clear error messages at init time.

## Root cause
Both `filters(kind=<peer>, populate_store=True)` and the subsequent
`filters(kind=<host>, populate_store=True)` write to the SDK store. The
host-node fetch returns each relation peer as a minimal stub and
overwrites the fully-hydrated peer that was cached a moment earlier.
`resolve_node_mapping` then reads `peer.<attr>.value` as `None` and
`ip_interface_to_ip_string(None)` raises
`AttributeError: 'NoneType' object has no attribute 'ip'`.

SDK `include=` is one-hop only
(`infrahub_sdk/node/node.py:1033` — plain list-membership check on `rel_name`, peer hydration does not propagate `include` or `prefetch_relationships`). Since the previous implementation did not
support multi-hop mappings either (`get_related_nodes` only walked one level), this change does not regress the feature surface.

## Test plan
- [ ] `uv run pytest tests/unit/` — all tests pass, including four new
tests covering include merging, single-segment no-op, multi-hop
rejection, and unknown-relationship rejection.
- [ ] `uv run python flow.py` against a live Infrahub returns all
devices with non-null `hostname` (IP), `platform`, and `site.*`
groups.

