### PR TITLE
fix: add support for schemas that don't have a name attribute

### DIFF
--- a/docs/docs/guides/configuring-schema-mappings.mdx
+++ b/docs/docs/guides/configuring-schema-mappings.mdx
@@ -131,6 +131,18 @@ host_node:
 
 :::
 
+### Customizing the Nornir host name
+
+By default, the plugin uses the node's `name` attribute as the Nornir host name. If your schema does not define a `name` attribute, or you want a different attribute to drive the host name, add a schema mapping whose `name` is `"name"`:
+
+```yaml
+schema_mappings:
+  - name: "name"
+    mapping: "hostname"  # Use the node's "hostname" attribute as the Nornir host name
+```
+
+The `mapping` follows the same rules as any other mapping, so you can also resolve the name through a single relationship (for example, `primary_address.address`). When no `name` mapping is provided and the node has no `name` attribute, the host is skipped.
+
 ### Multiple level nesting
 
 The plugin supports traversing one relationship level before reaching an attribute. For example, `site.name` follows the `site` relationship then reads its `name` attribute. Deeper chains (e.g., `site.location.name`) are not supported.

--- a/docs/docs/references/plugins/infrahub_inventory.mdx
+++ b/docs/docs/references/plugins/infrahub_inventory.mdx
@@ -18,7 +18,7 @@ from Infrahub Nodes.
 | `address` | `str` | No | `"http://localhost:8000"` | The Infrahub URL to connect to. |
 | `branch` | `str` | No | `"main"` | The Infrahub branch to use. |
 | `host_node` | `dict` | Yes | - | A dictionary defining the Infrahub Node kind that will be mapped to Nornir Hosts. Example: `{"kind": "InfraDevice"}` |
-| `schema_mappings` | `list` | No | `[]` | A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`. |
+| `schema_mappings` | `list` | No | `[]` | A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. A mapping with `name: "name"` customizes the Nornir host name (default: the node's `name` attribute). Example: `[{"name": "hostname", "mapping": "primary_address.address"}, {"name": "name", "mapping": "hostname"}]`. |
 | `group_mappings` | `list` | No | `[]` | A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`. |
 | `defaults_file` | `str` | No | `"defaults.yaml"` | Path to the defaults YAML file. |
 | `group_file` | `str` | No | `"group.yaml"` | Path to the group YAML file. |

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -211,14 +211,14 @@ class InfrahubInventory:
             parts = mapping.split(".")
             if len(parts) > MAX_RELATIONSHIP_HOPS:
                 raise ValueError(
-                    f"{source} '{mapping}' spans more than one relation hop; ",
-                    "only single-hop mappings (e.g. 'primary_address.address') are supported",
+                    f"{source} '{mapping}' spans more than one relation hop; "
+                    "only single-hop mappings (e.g. 'primary_address.address') are supported"
                 )
             if len(parts) == MAX_RELATIONSHIP_HOPS:
                 if parts[0] not in host_rel_names:
                     raise ValueError(
-                        f"{source} '{mapping}' references '{parts[0]}', ",
-                        f"which is not a relationship on {self.host_node.kind}",
+                        f"{source} '{mapping}' references '{parts[0]}', "
+                        f"which is not a relationship on {self.host_node.kind}"
                     )
                 mapping_relations.add(parts[0])
 
@@ -268,8 +268,8 @@ class InfrahubInventory:
                     name = resolve_node_mapping(host_node, name_mapping.mapping.split("."))
                 except RuntimeError as exc:
                     raise RuntimeError(
-                        f"Unable to resolve 'name' schema_mapping '{name_mapping.mapping}' ",
-                        f"on kind '{self.host_node.kind}'",
+                        f"Unable to resolve 'name' schema_mapping '{name_mapping.mapping}' "
+                        f"on kind '{self.host_node.kind}'"
                     ) from exc
             elif hasattr(host_node, "name"):
                 name = host_node.name.value

--- a/nornir_infrahub/plugins/inventory/infrahub.py
+++ b/nornir_infrahub/plugins/inventory/infrahub.py
@@ -129,7 +129,7 @@ class InfrahubInventory:
         address (str, optional): The Infrahub URL to connect to. Defaults to "http://localhost:8000".
         branch (str, optional): The Infrahub branch to use. Defaults to "main".
         host_node (dict): A dictionary defining the Infrahub Node kind that will be mapped to Nornir Hosts. Example: `{"kind": "InfraDevice"}`
-        schema_mappings (list): A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. Example: `[{"name": "hostname", "mapping": "primary_address.address"}]`.
+        schema_mappings (list): A list of mappings that define how Nornir Host properties correspond to attributes or relations from Infrahub Nodes. A mapping with `name: "name"` customizes the Nornir host name (default: the node's `name` attribute). Example: `[{"name": "hostname", "mapping": "primary_address.address"}, {"name": "name", "mapping": "hostname"}]`.
         group_mappings (list): A list of Infrahub Node attributes or relations used to create Nornir groups. Example: `["site.name"]`.
         defaults_file (str, optional): Path to the defaults YAML file. Defaults to "defaults.yaml".
         group_file (str, optional): Path to the group YAML file. Defaults to "group.yaml".
@@ -211,14 +211,14 @@ class InfrahubInventory:
             parts = mapping.split(".")
             if len(parts) > MAX_RELATIONSHIP_HOPS:
                 raise ValueError(
-                    f"{source} '{mapping}' spans more than one relation hop; "
-                    "only single-hop mappings (e.g. 'primary_address.address') are supported"
+                    f"{source} '{mapping}' spans more than one relation hop; ",
+                    "only single-hop mappings (e.g. 'primary_address.address') are supported",
                 )
             if len(parts) == MAX_RELATIONSHIP_HOPS:
                 if parts[0] not in host_rel_names:
                     raise ValueError(
-                        f"{source} '{mapping}' references '{parts[0]}', "
-                        f"which is not a relationship on {self.host_node.kind}"
+                        f"{source} '{mapping}' references '{parts[0]}', ",
+                        f"which is not a relationship on {self.host_node.kind}",
                     )
                 mapping_relations.add(parts[0])
 
@@ -260,8 +260,21 @@ class InfrahubInventory:
 
         host_nodes = self.get_resources(**dict(self.host_node))
 
+        name_mapping = next((m for m in self.schema_mappings if m.name == "name"), None)
+
         for host_node in host_nodes:
-            name = host_node.name.value
+            if name_mapping is not None:
+                try:
+                    name = resolve_node_mapping(host_node, name_mapping.mapping.split("."))
+                except RuntimeError as exc:
+                    raise RuntimeError(
+                        f"Unable to resolve 'name' schema_mapping '{name_mapping.mapping}' ",
+                        f"on kind '{self.host_node.kind}'",
+                    ) from exc
+            elif hasattr(host_node, "name"):
+                name = host_node.name.value
+            else:
+                continue
 
             for schema_mapping in self.schema_mappings:
                 attrs = schema_mapping.mapping.split(".")


### PR DESCRIPTION
schould be merged after #74 

When you used `nornir_infrahub` for a schema node, that doesn't define a name attribute in the schema, then the inventory would fail to load.

This fix allows you to define another attribute that can be mapped to a Nornir's host name property.

The default behavior is unchanged, if no name property mapping is provided, we will try to retrieve the value of the name attribute.